### PR TITLE
feat: mock the catalog download for the test

### DIFF
--- a/catalogue_tools/download/tests/data/catalog.csv
+++ b/catalogue_tools/download/tests/data/catalog.csv
@@ -1,0 +1,1275 @@
+#EventID|Time|Latitude|Longitude|Depth/km|Author|Catalog|Contributor|ContributorID|MagType|Magnitude|MagAuthor|EventLocationName|EventType
+smi:ch.ethz.sed/sc20a/Event/2021zihlix|2021-12-25T14:49:40.125942|47.371755|6.917057|3.4|tdiehl@sc20ag||SED|smi:ch.ethz.sed/sc20a/Event/2021zihlix|MLhc|3.5|tdiehl@sc20ag|Porrentruy JU|earthquake
+smi:ch.ethz.sed/sc20a/Event/2021zhdzar|2021-12-24T23:59:56.706839|47.373494|6.918607|4.4|tdiehl@sc20ag||SED|smi:ch.ethz.sed/sc20a/Event/2021zhdzar|MLhc|4.1|tdiehl@sc20ag|Porrentruy JU|earthquake
+smi:ch.ethz.sed/sc20a/Event/2021yvcxya|2021-12-18T10:34:47.61817|45.620467|9.606284|26.2|tdiehl@sc20ag||SED|smi:ch.ethz.sed/sc20a/Event/2021yvcxya|MLhc|4.4|tdiehl@sc20ag|Bergamo I|earthquake
+smi:ch.ethz.sed/sc20a/Event/2021yhkcdx|2021-12-10T23:08:13.459475|47.425691|7.741699|25.2|tdiehl@sc20ag||SED|smi:ch.ethz.sed/sc20a/Event/2021yhkcdx|MLhc|3.2|tdiehl@sc20ag|Liestal BL|earthquake
+smi:ch.ethz.sed/sc20a/Event/2021vntams|2021-11-01T22:15:39.657216|47.129280|6.555207|13.7|tdiehl@sc20ag||SED|smi:ch.ethz.sed/sc20a/Event/2021vntams|MLhc|3.1|tdiehl@sc20ag|Valdahon F|earthquake
+smi:ch.ethz.sed/sc20a/Event/2021toxjpc|2021-10-05T05:39:25.176962|45.974921|7.515446|1.0|tdiehl@sc20ag||SED|smi:ch.ethz.sed/sc20a/Event/2021toxjpc|MLhc|4.1|tdiehl@sc20ag|Arolla VS|earthquake
+smi:ch.ethz.sed/sc20a/Event/2021tmyqyy|2021-10-04T04:09:32.644805|45.992096|7.502448|0.6|tdiehl@sc20ag||SED|smi:ch.ethz.sed/sc20a/Event/2021tmyqyy|MLhc|3.1|tdiehl@sc20ag|Arolla VS|earthquake
+smi:ch.ethz.sed/sc20a/Event/2021tkkkpf|2021-10-02T18:49:38.597314|48.011700|7.095051|9.8|tdiehl@sc20ag||SED|smi:ch.ethz.sed/sc20a/Event/2021tkkkpf|MLhc|3.0|tdiehl@sc20ag|Colmar F|earthquake
+smi:ch.ethz.sed/sc20a/Event/2021mvcsag|2021-07-01T11:11:50.282499|46.612324|8.373587|8.3|tdiehl@sc20ag||SED|smi:ch.ethz.sed/sc20a/Event/2021mvcsag|MLhc|4.0|tdiehl@sc20ag|Oberwald VS|earthquake
+smi:ch.ethz.sed/sc20a/Event/2021mskckn|2021-06-29T23:45:09.192891|47.675274|8.988000|12.6|tdiehl@sc20ag||SED|smi:ch.ethz.sed/sc20a/Event/2021mskckn|MLhc|3.1|tdiehl@sc20ag|Steckborn TG|earthquake
+smi:ch.ethz.sed/sc3a/2021ffattd|2021-03-15T13:27:35.630776|46.893909|7.423484|5.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2021ffattd|MLhc|3.2|tdiehl@sc3ag|Bern|earthquake
+smi:ch.ethz.sed/sc3a/2021efvbrf|2021-03-01T19:43:36.47527|47.686419|9.060667|22.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2021efvbrf|MLhc|3.1|tdiehl@sc3ag|Steckborn TG|earthquake
+smi:ch.ethz.sed/sc3a/2021cnisvd|2021-02-05T14:14:11.661805|47.750527|8.825253|10.9|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2021cnisvd|MLhc|3.2|tdiehl@sc3ag|Singen D|earthquake
+smi:ch.ethz.sed/sc3a/2020wfjqus|2020-11-10T12:53:23.115762|46.903112|9.115465|1.7|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020wfjqus|MLhc|3.9|tdiehl@sc3ag|Elm GL|earthquake
+smi:ch.ethz.sed/sc3a/2020wcoepg|2020-11-08T23:56:43.168171|45.971445|7.518062|2.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020wcoepg|MLhc|3.5|tdiehl@sc3ag|Arolla VS|earthquake
+smi:ch.ethz.sed/sc3a/2020vcswxa|2020-10-25T22:23:35.341294|46.905565|9.133949|1.7|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020vcswxa|MLh|3.1|tdiehl@sc3ag|Elm GL|earthquake
+smi:ch.ethz.sed/sc3a/2020vcnoon|2020-10-25T19:43:09.942212|46.905974|9.124711|1.4|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020vcnoon|MLh|3.6|tdiehl@sc3ag|Elm GL|earthquake
+smi:ch.ethz.sed/sc3a/2020vcnjhp|2020-10-25T19:35:43.383892|46.904747|9.124708|1.4|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020vcnjhp|MLh|4.3|tdiehl@sc3ag|Elm GL|earthquake
+smi:ch.ethz.sed/sc3a/2020pwuynz|2020-08-12T21:15:48.889351|46.017660|7.713770|3.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020pwuynz|MLh|3.0|tdiehl@sc3ag|Zermatt VS|earthquake
+smi:ch.ethz.sed/sc3a/2020ppteci|2020-08-09T00:50:36.420796|47.178037|10.668849|8.9|toni@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020ppteci|MLh|3.0|toni@sc3ag|Imst A|earthquake
+smi:ch.ethz.sed/sc3a/2020ppjaof|2020-08-08T19:44:45.743049|47.179265|10.665896|8.8|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020ppjaof|MLh|4.0|tdiehl@sc3ag|Imst A|earthquake
+smi:ch.ethz.sed/sc3a/2020mhxdlt|2020-06-23T06:25:41.127671|46.038519|6.919141|4.9|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020mhxdlt|MLh|3.8|tdiehl@sc3ag|Chamonix F|earthquake
+smi:ch.ethz.sed/sc3a/2020kilqlz|2020-05-26T05:50:25.805139|46.907406|9.136520|2.1|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020kilqlz|MLh|3.1|tdiehl@sc3ag|Elm GL|earthquake
+smi:ch.ethz.sed/sc3a/2020bxkqyj|2020-01-27T22:05:41.108176|48.299315|8.951312|7.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020bxkqyj|MLh|3.5|tdiehl@sc3ag|Albstadt D|earthquake
+smi:ch.ethz.sed/sc3a/2020btnrcj|2020-01-25T19:13:28.756778|46.235240|7.714763|3.7|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2020btnrcj|MLh|3.0|tdiehl@sc3ag|Graechen VS|earthquake
+smi:ch.ethz.sed/sc3a/2019xnlhez|2019-11-30T02:14:45.70461|46.100275|7.304213|4.2|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019xnlhez|MLh|3.0|tdiehl@sc3ag|Verbier VS|earthquake
+smi:ch.ethz.sed/sc3a/2019vymbwi|2019-11-07T18:35:38.681397|46.317446|7.355378|4.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019vymbwi|MLh|3.2|tdiehl@sc3ag|Sanetschpass VS|earthquake
+smi:ch.ethz.sed/sc3a/2019vuxdnw|2019-11-05T19:51:13.934609|46.316628|7.361496|5.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019vuxdnw|MLh|3.2|tdiehl@sc3ag|Sanetschpass VS|earthquake
+smi:ch.ethz.sed/sc3a/2019vtyeym|2019-11-05T07:18:42.733245|46.324808|7.363282|5.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019vtyeym|MLh|3.0|tdiehl@sc3ag|Sanetschpass VS|earthquake
+smi:ch.ethz.sed/sc3a/2019vtqvxb|2019-11-05T03:36:50.15228|46.317855|7.362474|4.7|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019vtqvxb|MLh|3.3|tdiehl@sc3ag|Sanetschpass VS|earthquake
+smi:ch.ethz.sed/sc3a/2019vtllwo|2019-11-05T00:54:21.256705|46.318264|7.365509|4.8|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019vtllwo|MLh|3.3|tdiehl@sc3ag|Sanetschpass VS|earthquake
+smi:ch.ethz.sed/sc3a/2019vrpxrf|2019-11-04T00:59:46.4198|48.235378|8.999979|6.6|lanzaf@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019vrpxrf|MLh|3.9|lanzaf@sc3ag|Albstadt D|earthquake
+smi:ch.ethz.sed/sc3a/2019rmmvxa|2019-09-05T14:19:19.698759|47.746028|9.107935|3.2|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019rmmvxa|MLh|3.0|tdiehl@sc3ag|Konstanz D|earthquake
+smi:ch.ethz.sed/sc3a/2019qzqwtc|2019-08-29T14:22:49.535421|47.743983|9.110017|3.1|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019qzqwtc|MLh|3.4|tdiehl@sc3ag|Konstanz D|earthquake
+smi:ch.ethz.sed/sc3a/2019qofceu|2019-08-23T08:38:34.032052|46.205384|7.558381|5.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019qofceu|MLh|3.0|tdiehl@sc3ag|Zinal VS|earthquake
+smi:ch.ethz.sed/sc3a/2019oxtgem|2019-07-31T05:32:27.100551|47.740303|9.113138|4.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019oxtgem|MLh|3.1|tdiehl@sc3ag|Konstanz D|earthquake
+smi:ch.ethz.sed/sc3a/2019ovnxpr|2019-07-30T00:42:41.550703|47.737440|9.113132|3.9|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019ovnxpr|MLh|3.2|tdiehl@sc3ag|Konstanz D|earthquake
+smi:ch.ethz.sed/sc3a/2019ovlclr|2019-07-29T23:17:47.572629|47.739485|9.110007|3.7|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019ovlclr|MLh|3.7|tdiehl@sc3ag|Konstanz D|earthquake
+smi:ch.ethz.sed/sc3a/2019lilwwt|2019-06-10T09:54:15.652258|48.265643|7.286804|1.0|fgrigoli@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019lilwwt|MLh|3.1|fgrigoli@sc3ag|Colmar F|earthquake
+smi:de.uni-freiburg.lgrb/out.227844-0.251975193780549/20190528085143/event/1|2019-05-28T08:48:05.740162|46.372863|6.745317|4.4|tdiehl@sc3ag||LED|smi:de.uni-freiburg.lgrb/out.227844-0.251975193780549/20190528085143/event/1|MLh|4.2|tdiehl@sc3ag|Montreux VD|earthquake
+smi:ch.ethz.sed/sc3a/2019ffctbw|2019-03-15T14:31:50.951213|45.884740|7.038763|2.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019ffctbw|MLh|3.1|tdiehl@sc3ag|Bourg-Saint-Pierre VS|earthquake
+smi:ch.ethz.sed/sc3a/2019ffcolv|2019-03-15T14:21:19.33998|45.887194|7.044722|2.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019ffcolv|MLh|3.1|tdiehl@sc3ag|Bourg-Saint-Pierre VS|earthquake
+smi:ch.ethz.sed/sc3a/2019cnxgzz|2019-02-05T21:32:59.690657|46.040179|5.666374|5.8|fgrigoli@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019cnxgzz|MLh|3.2|fgrigoli@sc3ag|Bellegarde-sur-Valserine F|earthquake
+smi:ch.ethz.sed/sc3a/2019cmxjdl|2019-02-05T08:30:59.956637|45.876765|7.020407|3.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2019cmxjdl|MLh|3.1|tdiehl@sc3ag|Courmayeur I|earthquake
+smi:ch.ethz.sed/sc3a/2018qnofko|2018-08-23T00:09:09.789461|46.187082|7.084482|6.1|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2018qnofko|MLh|3.2|tdiehl@sc3ag|Saxon VS|earthquake
+smi:ch.ethz.sed/sc3a/2018myltym|2018-07-03T06:58:47.745174|45.450372|6.349793|2.8|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2018myltym|MLh|3.1|tdiehl@sc3ag|Mont-Cenis F|earthquake
+smi:ch.ethz.sed/sc3a/2018jneapm|2018-05-15T15:30:20.092421|46.515599|6.868840|1.5|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2018jneapm|MLh|3.1|tdiehl@sc3ag|CHATEL-ST-DENIS FR|earthquake
+smi:ch.ethz.sed/sc3a/2018itlhmz|2018-05-04T21:36:41.778711|47.766887|7.518773|15.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2018itlhmz|MLh|3.3|tdiehl@sc3ag|Muellheim D|earthquake
+smi:ch.ethz.sed/sc3a/2018hdpcyy|2018-04-12T02:23:59.083046|47.153614|10.009690|0.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2018hdpcyy|MLh|3.2|tdiehl@sc3ag|Montafon A|earthquake
+smi:ch.ethz.sed/sc3a/2018eylvfl|2018-03-11T23:29:22.830452|47.672411|8.014124|17.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2018eylvfl|MLh|3.1|tdiehl@sc3ag|Laufenburg|earthquake
+smi:ch.ethz.sed/sc3a/2018cfbbyr|2018-02-01T01:47:33.109241|47.153205|9.996274|1.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2018cfbbyr|MLh|4.1|tdiehl@sc3ag|Montafon A|earthquake
+smi:ch.ethz.sed/sc3a/2018bevqtj|2018-01-17T19:07:19.446511|47.145026|9.987871|1.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2018bevqtj|MLh|4.1|tdiehl@sc3ag|Montafon A|earthquake
+smi:ch.ethz.sed/sc3a/2017wxlpto|2017-11-21T09:22:01.498462|47.145333|8.545990|31.7|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017wxlpto|MLh|3.3|tdiehl@sc3ag|ZUG|earthquake
+smi:ch.ethz.sed/sc3a/2017wqiouu|2017-11-17T12:10:24.734249|45.448223|6.365033|8.6|toni@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017wqiouu|MLh|3.4|toni@sc3ag|Mont-Cenis F|earthquake
+smi:ch.ethz.sed/sc3a/2017voyqdt|2017-11-02T14:09:08.713492|46.331965|7.527114|4.4|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017voyqdt|MLh|3.1|tdiehl@sc3ag|Sierre VS|earthquake
+smi:ch.ethz.sed/sc3a/2017rilinz|2017-09-03T09:15:46.729012|45.726086|10.628849|4.2|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017rilinz|MLh|3.4|tdiehl@sc3ag|Lago di Garda I|earthquake
+smi:ch.ethz.sed/sc3a/2017qocwbh|2017-08-23T07:30:27.931602|46.263818|9.570512|-2.7|jclinton@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017qocwbh|MLh|3.0|jclinton@sc3ag|Soglio GR|landslide
+smi:ch.ethz.sed/sc3a/2017oggxfq|2017-07-21T17:03:55.765469|45.686172|10.661619|5.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017oggxfq|MLh|3.6|tdiehl@sc3ag|Lago di Garda I|earthquake
+smi:ch.ethz.sed/sc3a/2017muwsar|2017-07-01T08:10:34.076731|46.491264|7.097482|4.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017muwsar|MLh|4.3|tdiehl@sc3ag|CHATEAU-D'OEX VD|earthquake
+smi:ch.ethz.sed/sc3a/2017laxuul|2017-06-06T07:18:03.207743|46.727453|7.232926|5.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017laxuul|MLh|3.3|tdiehl@sc3ag|Schwarzsee FR|earthquake
+smi:ch.ethz.sed/sc3a/2017kumiqj|2017-06-02T19:05:12.904778|46.266732|7.300085|6.8|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017kumiqj|MLh|3.3|tdiehl@sc3ag|Sion VS|earthquake
+smi:ch.ethz.sed/sc3a/2017fousih|2017-03-20T21:09:10.505951|46.044244|6.904778|4.2|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017fousih|MLh|3.0|tdiehl@sc3ag|Chamonix F|earthquake
+smi:ch.ethz.sed/sc3a/2017fnfrhj|2017-03-20T00:30:55.10341|46.040154|6.908975|3.7|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017fnfrhj|MLh|3.3|tdiehl@sc3ag|Chamonix F|earthquake
+smi:ch.ethz.sed/sc3a/2017epaqsp|2017-03-06T20:12:07.401209|46.906690|8.925294|4.2|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2017epaqsp|MLh|4.6|tdiehl@sc3ag|Linthal GL|earthquake
+smi:ch.ethz.sed/sc3a/2016zezzai|2016-12-22T19:50:17.470596|46.367546|6.758750|-0.4|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016zezzai|MLh|3.4|tdiehl@sc3ag|Montreux VD|earthquake
+smi:ch.ethz.sed/sc3a/2016zeyzpu|2016-12-22T19:24:14.736265|46.366729|6.756751|-0.7|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016zeyzpu|MLh|3.0|tdiehl@sc3ag|Montreux VD|earthquake
+smi:ch.ethz.sed/sc3a/2016vrzmka|2016-11-03T05:48:21.991199|47.775475|8.784467|7.1|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016vrzmka|MLh|3.0|tdiehl@sc3ag|Singen D|earthquake
+smi:ch.ethz.sed/sc3a/2016vahyzy|2016-10-24T14:44:11.584989|46.338304|7.580278|8.2|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016vahyzy|MLh|4.1|tdiehl@sc3ag|Leukerbad VS|earthquake
+smi:ch.ethz.sed/sc3a/2016tuodjl|2016-10-07T07:27:07.298413|46.514167|9.543707|10.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016tuodjl|MLh|3.8|tdiehl@sc3ag|Juf GR|earthquake
+smi:ch.ethz.sed/sc3a/2016tnduus|2016-10-03T06:43:43.460716|46.669172|8.512954|4.9|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016tnduus|MLh|3.2|tdiehl@sc3ag|Goeschenen UR|earthquake
+smi:ch.ethz.sed/sc3a/2016tkthnp|2016-10-01T23:17:39.004961|46.033202|6.878930|5.4|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016tkthnp|MLh|3.4|tdiehl@sc3ag|Chamonix F|earthquake
+smi:ch.ethz.sed/sc3a/2016rxorfe|2016-09-10T15:13:52.413971|45.421511|9.642174|44.9|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016rxorfe|MLh|3.2|tdiehl@sc3ag|Bergamo I|earthquake
+smi:ch.ethz.sed/sc3a/2016mjoljx|2016-06-24T04:12:17.00442|46.261824|7.401684|8.2|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016mjoljx|MLh|3.2|tdiehl@sc3ag|Sion VS|earthquake
+smi:ch.ethz.sed/sc3a/2016hefrde|2016-04-11T10:47:23.027884|46.431144|10.015052|7.6|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016hefrde|MLh|3.2|tdiehl@sc3ag|Poschiavo GR|earthquake
+smi:ch.ethz.sed/sc3a/2016hbjhww|2016-04-09T21:19:43.005665|46.037701|6.878758|4.9|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016hbjhww|MLh|3.0|tdiehl@sc3ag|Chamonix F|earthquake
+smi:ch.ethz.sed/sc3a/2016djvmdl|2016-02-17T20:17:04.497392|47.100665|10.086835|5.1|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016djvmdl|MLh|3.0|tdiehl@sc3ag|Montafon A|earthquake
+smi:ch.ethz.sed/sc3a/2016ckfzgr|2016-02-03T21:37:39.432584|45.763544|10.723282|9.2|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016ckfzgr|MLh|3.0|tdiehl@sc3ag|Lago di Garda I|earthquake
+smi:ch.ethz.sed/sc3a/2016ceuzts|2016-01-31T22:43:58.992628|47.100665|10.086835|5.8|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016ceuzts|MLh|3.5|tdiehl@sc3ag|Montafon A|earthquake
+smi:ch.ethz.sed/sc3a/2016awfdsn|2016-01-13T02:13:37.096064|47.361027|6.284449|17.3|toni@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016awfdsn|MLh|3.1|toni@sc3ag|BESANCON F|earthquake
+smi:ch.ethz.sed/sc3a/2016acratl|2016-01-02T10:42:44.598405|46.528891|7.997355|6.9|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2016acratl|MLh|3.1|tdiehl@sc3ag|Muerren BE|earthquake
+smi:ch.ethz.sed/sc3a/2015xlgcxd|2015-11-28T21:29:56.634979|45.762250|9.797220|11.9|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2015xlgcxd|MLh|3.3|tdiehl@sc3ag|Bergamo I|earthquake
+smi:ch.ethz.sed/sc3a/2015ufadda|2015-10-14T00:13:45.055483|46.330942|7.524603|4.4|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2015ufadda|MLh|3.1|tdiehl@sc3ag|Sierre VS|earthquake
+smi:ch.ethz.sed/sc3a/2015qzojrg|2015-08-29T13:07:19.081028|46.688936|10.642911|9.4|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2015qzojrg|MLh|3.1|tdiehl@sc3ag|Santa Maria GR|earthquake
+smi:ch.ethz.sed/sc3a/2015mawiuf|2015-06-20T10:30:22.534321|46.259779|7.403773|9.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2015mawiuf|MLh|3.1|tdiehl@sc3ag|Sion VS|earthquake
+smi:ch.ethz.sed/sc3a/2015lrdhbf|2015-06-15T03:14:47.034993|45.900895|7.351131|2.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2015lrdhbf|MLh|3.1|tdiehl@sc3ag|Bourg-Saint-Pierre VS|earthquake
+smi:ch.ethz.sed/sc3a/2015dripah|2015-02-21T22:23:58.259748|47.883038|8.222421|24.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2015dripah|MLh|3.2|tdiehl@sc3ag|Schluchsee D|earthquake
+smi:ch.ethz.sed/sc3a/2015cetioe|2015-01-31T21:54:01.769315|47.152183|7.143049|10.1|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2015cetioe|MLh|3.1|tdiehl@sc3ag|Biel BE|earthquake
+smi:ch.ethz.sed/sc3a/2015bxouam|2015-01-28T00:05:01.05566|48.203214|8.966149|12.7|jclinton@sc3ag||SED|smi:ch.ethz.sed/sc3a/2015bxouam|MLh|3.4|jclinton@sc3ag|Albstadt D|earthquake
+smi:ch.ethz.sed/sc3a/2015btkjts|2015-01-25T17:34:26.607649|46.777349|10.160330|7.2|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2015btkjts|MLh|3.1|tdiehl@sc3ag|Zernez GR|earthquake
+smi:ch.ethz.sed/sc3a/2014yufzii|2014-12-17T23:04:26.492269|46.791459|6.782647|29.2|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2014yufzii|MLh|3.1|tdiehl@sc3ag|Yvonand VD|earthquake
+smi:ch.ethz.sed/sc3a/2014ypiosj|2014-12-15T06:58:17.922639|47.514134|9.146918|25.3|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2014ypiosj|MLh|3.3|tdiehl@sc3ag|Weinfelden TG|earthquake
+smi:ch.ethz.sed/sc3a/2014xcagag|2014-11-23T20:52:15.998447|46.030543|6.873476|4.6|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2014xcagag|MLh|3.2|tdiehl@sc3ag|Chamonix F|earthquake
+smi:ch.ethz.sed/sc3a/2014wkfqbh|2014-11-14T04:14:12.08315|47.129689|9.186058|-0.4|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2014wkfqbh|MLh|3.1|tdiehl@sc3ag|Walenstadt SG|earthquake
+smi:ch.ethz.sed/sc3a/2014vlemkm|2014-10-31T12:47:57.553745|48.202907|8.977509|11.1|jclinton@sc3ag||SED|smi:ch.ethz.sed/sc3a/2014vlemkm|MLh|3.1|jclinton@sc3ag|Albstadt D|earthquake
+smi:ch.ethz.sed/sc3a/2014uiiklu|2014-10-15T19:36:32.914612|46.652813|7.571021|9.5|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2014uiiklu|MLh|3.2|tdiehl@sc3ag|Diemtigen BE|earthquake
+smi:ch.ethz.sed/sc3a/2014qybzvf|2014-08-28T17:49:19.576365|45.637354|10.663207|3.6|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/2014qybzvf|MLh|4.1|tdiehl@sc3ag|Lago di Garda I|earthquake
+smi:ch.ethz.sed/sc3a/2014plbfwz|2014-08-07T11:31:39.801269|48.054150|8.078170|11.8|toni@sc3ag||SED|smi:ch.ethz.sed/sc3a/2014plbfwz|MLh|3.3|toni@sc3ag|Freiburg im Breisgau D|earthquake
+smi:ch.ethz.sed/sc3rp/2014dxarwl|2014-02-25T00:52:45.052562|46.239125|7.838893|6.1|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3rp/2014dxarwl|MLh|3.0|tdiehl@sc3ag|Graechen VS|earthquake
+smi:de.uni-freiburg.lgrb/out.70262-0.49573829662835/20140108183648/event/1|2014-01-08T18:27:48.625561|47.153819|7.150212|9.7|tdiehl@sc3ag||LED|smi:de.uni-freiburg.lgrb/out.70262-0.49573829662835/20140108183648/event/1|MLh|3.2|tdiehl@sc3ag|Biel BE|earthquake
+smi:ch.ethz.sed/sc3rp/2013zljqbd|2013-12-27T07:08:28.3498|47.057708|9.495690|6.2|tdiehl@sc3rg||SED|smi:ch.ethz.sed/sc3rp/2013zljqbd|MLh|3.7|tdiehl@sc3rg|Sargans SG|earthquake
+smi:ch.ethz.sed/sc3rp/2013yjjmte|2013-12-12T00:59:18.86411|47.057708|9.490542|5.9|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3rp/2013yjjmte|MLh|4.1|tdiehl@sc3ag|Sargans SG|earthquake
+smi:ch.ethz.sed/sc3rp/2013obrn|2013-07-20T03:30:54.915087|47.420886|9.315622|4.5|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3rp/2013obrn|MLh|3.5|tdiehl@sc3ag|Herisau AR|earthquake
+smi:ch.ethz.sed/sc3rp/2013mxlf|2013-07-03T14:13:50.453984|47.318026|7.391217|24.6|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3rp/2013mxlf|MLh|3.2|tdiehl@sc3ag|Moutier BE|earthquake
+smi:at.zamg/out.52470-0.846935247495662/20130420122528/event/1|2013-04-20T12:21:33.251596|47.221635|10.090005|4.0|tdiehl@sc3ag||ZAMG|smi:at.zamg/out.52470-0.846935247495662/20130420122528/event/1|MLh|3.4|tdiehl@sc3ag|St. Anton am Arlberg A|earthquake
+smi:ch.ethz.sed/sc3rp/2013dyew|2013-02-25T22:19:24.874036|45.640731|10.017438|7.8|toni@sc3rg||SED|smi:ch.ethz.sed/sc3rp/2013dyew|MLh|3.2|toni@sc3rg|Lago d'Iseo  I|earthquake
+smi:ch.ethz.sed/sc3rp/2012wmwe|2012-11-16T02:37:12.541625|45.847670|10.917026|13.0|toni@sc3rg||SED|smi:ch.ethz.sed/sc3rp/2012wmwe|MLh|3.1|toni@sc3rg|Lago di Garda I|earthquake
+smi:ch.ethz.sed/sc3rp/2012uyog|2012-10-25T01:10:57.610844|46.034633|6.895545|4.4|tdiehl@sc3rg||SED|smi:ch.ethz.sed/sc3rp/2012uyog|MLh|3.6|tdiehl@sc3rg|Chamonix F|earthquake
+smi:ch.ethz.sed/KP201203181559.MANUPDEPICK/20121012194223/event/1|2012-03-18T16:00:00.6|45.786000|10.964000|2.3|ndeich||SED_KP|smi:ch.ethz.sed/KP201203181559.MANUPDEPICK/20121012194223/event/1|Ml|3.3|ndeich|Northern Italy|earthquake
+smi:ch.ethz.sed/KP201203160230.MANUPDEPICK/20121012194223/event/1|2012-03-16T02:31:13.3|46.692000|11.070000|9.8|jclinton||SED_KP|smi:ch.ethz.sed/KP201203160230.MANUPDEPICK/20121012194223/event/1|Ml|3.4|jclinton|Northern Italy|earthquake
+smi:ch.ethz.sed/KP201202240032.MANUPDEPICK/20121012194222/event/1|2012-02-24T00:32:29.8|47.144000|8.534000|32.4|ndeich||SED_KP|smi:ch.ethz.sed/KP201202240032.MANUPDEPICK/20121012194222/event/1|Ml|3.5|ndeich|Zug / Switzerland|earthquake
+smi:ch.ethz.sed/KP201202112245.MANUPDEPICK/20121012194222/event/1|2012-02-11T22:45:26.8|47.149000|8.553000|32.4|jclinton||SED_KP|smi:ch.ethz.sed/KP201202112245.MANUPDEPICK/20121012194222/event/1|Ml|4.2|jclinton|ZUG|earthquake
+smi:ch.ethz.sed/KP201201242354.MANUPDEPICK/20121012194221/event/1|2012-01-24T23:54:45.5|45.516000|10.887000|2.0|ndeich||SED_KP|smi:ch.ethz.sed/KP201201242354.MANUPDEPICK/20121012194221/event/1|Ml|4.4|ndeich|Northern Italy|earthquake
+smi:ch.ethz.sed/KP201201020142.MANUPDEPICK/20121012194221/event/1|2012-01-02T01:42:57.4|46.700000|9.737000|8.0|ndeich||SED_KP|smi:ch.ethz.sed/KP201201020142.MANUPDEPICK/20121012194221/event/1|Ml|3.5|ndeich|Filisur / Switzerland|earthquake
+smi:ch.ethz.sed/KP201201011533.MANUPDEPICK/20121012194221/event/1|2012-01-01T15:33:49.7|46.698000|9.737000|7.5|ndeich||SED_KP|smi:ch.ethz.sed/KP201201011533.MANUPDEPICK/20121012194221/event/1|Ml|3.3|ndeich|Filisur / Switzerland|earthquake
+smi:ch.ethz.sed/KP201112270628.MANUPDEPICK/20121012194221/event/1|2011-12-27T06:29:01.9|47.339000|7.315000|11.4|ndeich||SED_KP|smi:ch.ethz.sed/KP201112270628.MANUPDEPICK/20121012194221/event/1|Ml|3.1|ndeich|Delemont / Switzerland|earthquake
+smi:ch.ethz.sed/KP201110290413.MANUPDEPICK/20121012194219/event/1|2011-10-29T04:13:34.8|45.728000|10.790000|16.0|jclinton||SED_KP|smi:ch.ethz.sed/KP201110290413.MANUPDEPICK/20121012194219/event/1|Ml|4.2|jclinton|Northern Italy|earthquake
+smi:ch.ethz.sed/KP201101270124.MANUPDEPICK/20121012194217/event/1|2011-01-27T01:24:18.1|47.482000|9.844000|31.0|ndeich||SED_KP|smi:ch.ethz.sed/KP201101270124.MANUPDEPICK/20121012194217/event/1|Ml|3.3|ndeich|Egg / Austria|earthquake
+smi:ch.ethz.sed/KP201101082220.MANUPDEPICK/20121012194217/event/1|2011-01-08T22:20:26.3|46.302000|7.516000|6.4|ndeich||SED_KP|smi:ch.ethz.sed/KP201101082220.MANUPDEPICK/20121012194217/event/1|Ml|3.2|ndeich|Sierre / Switzerland|earthquake
+smi:ch.ethz.sed/KP201101082048.MANUPDEPICK/20121012194217/event/1|2011-01-08T20:48:17.3|46.304000|7.516000|6.7|ndeich||SED_KP|smi:ch.ethz.sed/KP201101082048.MANUPDEPICK/20121012194217/event/1|Ml|3.3|ndeich|Sierre / Switzerland|earthquake
+smi:ch.ethz.sed/KP201012250512.MANUPDEPICK/20121012194216/event/1|2010-12-25T05:12:33.9|45.945000|9.903000|-0.1|ndeich||SED_KP|smi:ch.ethz.sed/KP201012250512.MANUPDEPICK/20121012194216/event/1|Ml|3.3|ndeich|P. Arera / Italy|earthquake
+smi:ch.ethz.sed/KP201012060641.MANUPDEPICK/20121012194216/event/1|2010-12-06T06:41:24.7|46.033000|6.913000|4.2|ndeich||SED_KP|smi:ch.ethz.sed/KP201012060641.MANUPDEPICK/20121012194216/event/1|Ml|3.2|ndeich|Col de Balme / France|earthquake
+smi:ch.ethz.sed/KP201011121241.MANUPDEPICK/20121012194216/event/1|2010-11-12T12:42:06.3|46.642000|6.805000|8.4|ndeich||SED_KP|smi:ch.ethz.sed/KP201011121241.MANUPDEPICK/20121012194216/event/1|Ml|3.0|ndeich|Moudon / Switzerland|earthquake
+smi:ch.ethz.sed/KP201010252000.MANUPDEPICK/20121012194216/event/1|2010-10-25T20:00:30.8|47.243000|9.564000|2.8|ndeich||SED_KP|smi:ch.ethz.sed/KP201010252000.MANUPDEPICK/20121012194216/event/1|Ml|3.0|ndeich|Feldkirch / Switzerland|earthquake
+smi:ch.ethz.sed/KP201008110128.MANUPDEPICK/20121012194215/event/1|2010-08-11T01:28:55.4|45.546000|7.845000|3.0|shusen||SED_KP|smi:ch.ethz.sed/KP201008110128.MANUPDEPICK/20121012194215/event/1|Ml|3.4|shusen|Northern Italy|earthquake
+smi:ch.ethz.sed/KP201007090627.MANUPDEPICK/20121012194215/event/1|2010-07-09T06:28:09.2|47.244000|10.738000|-1.4|jclinton||SED_KP|smi:ch.ethz.sed/KP201007090627.MANUPDEPICK/20121012194215/event/1|Ml|3.0|jclinton|Austria|earthquake
+smi:ch.ethz.sed/KP201006301153.MANUPDEPICK/20121012194215/event/1|2010-06-30T11:53:44.6|45.415000|6.538000|10.8|jclinton||SED_KP|smi:ch.ethz.sed/KP201006301153.MANUPDEPICK/20121012194215/event/1|Ml|3.7|jclinton|France|earthquake
+smi:ch.ethz.sed/KP201005150509.MANUPDEPICK/20121012194215/event/1|2010-05-15T05:09:43.9|46.150000|7.747000|6.7|ndeich||SED_KP|smi:ch.ethz.sed/KP201005150509.MANUPDEPICK/20121012194215/event/1|Ml|3.4|ndeich|St. Niklaus / Switzerland|earthquake
+smi:ch.ethz.sed/KP201005110213.MANUPDEPICK/20121012194215/event/1|2010-05-11T02:13:41.8|45.718000|9.745000|12.7|ndeich||SED_KP|smi:ch.ethz.sed/KP201005110213.MANUPDEPICK/20121012194215/event/1|Ml|3.5|ndeich|Albino / Italy|earthquake
+smi:ch.ethz.sed/KP201004042116.MANUPDEPICK/20121012194214/event/1|2010-04-04T21:16:29.1|45.860000|7.506000|7.0|ndeich||SED_KP|smi:ch.ethz.sed/KP201004042116.MANUPDEPICK/20121012194214/event/1|Ml|3.3|ndeich|Valtournanche / Italy|earthquake
+smi:ch.ethz.sed/KP201003021816.MANUPDEPICK/20121012194214/event/1|2010-03-02T18:16:40.7|48.284000|8.989000|10.0|ndeich||SED_KP|smi:ch.ethz.sed/KP201003021816.MANUPDEPICK/20121012194214/event/1|Ml|3.1|ndeich|Germany|earthquake
+smi:ch.ethz.sed/KP200912081543.MANUPDEPICK/20121109201902/event/1|2009-12-08T15:43:52.7|45.487000|10.066000|35.9|jclinton||SED_KP|smi:ch.ethz.sed/KP200912081543.MANUPDEPICK/20121109201902/event/1|Ml|3.0|jclinton|Northern Italy|earthquake
+smi:ch.ethz.sed/KP200910211610.MANUPDEPICK/20121109201902/event/1|2009-10-21T16:10:58.7|46.128000|6.747000|6.4|ndeich||SED_KP|smi:ch.ethz.sed/KP200910211610.MANUPDEPICK/20121109201902/event/1|Ml|3.1|ndeich|Morillon / France|earthquake
+smi:ch.ethz.sed/KP200909110634.MANUPDEPICK/20121109201902/event/1|2009-09-11T06:34:38.1|46.527000|9.696000|11.3|ndeich||SED_KP|smi:ch.ethz.sed/KP200909110634.MANUPDEPICK/20121109201902/event/1|Ml|3.6|ndeich|Bivio / Switzerland|earthquake
+smi:ch.ethz.sed/KP200905050139.MANUPDEPICK/20121109201902/event/1|2009-05-05T01:39:25.1|47.674000|7.748000|11.7|ndeich||SED_KP|smi:ch.ethz.sed/KP200905050139.MANUPDEPICK/20121109201902/event/1|Ml|4.2|ndeich|Zell / Germany|earthquake
+smi:ch.ethz.sed/KP200901170709.MANUPDEPICK/20121109201901/event/1|2009-01-17T07:09:57.8|47.139000|9.529000|4.7|ndeich||SED_KP|smi:ch.ethz.sed/KP200901170709.MANUPDEPICK/20121109201901/event/1|Ml|3.0|ndeich|Buchs / Switzerland|earthquake
+smi:ch.ethz.sed/KP200901041548.MANUPDEPICK/20121109201901/event/1|2009-01-04T15:48:47.3|47.176000|9.377000|5.3|ndeich||SED_KP|smi:ch.ethz.sed/KP200901041548.MANUPDEPICK/20121109201901/event/1|Ml|3.1|ndeich|Buchs / Switzerland|earthquake
+smi:ch.ethz.sed/KP200901041530.MANUPDEPICK/20121109201901/event/1|2009-01-04T15:30:30.1|47.173000|9.361000|4.5|ndeich||SED_KP|smi:ch.ethz.sed/KP200901041530.MANUPDEPICK/20121109201901/event/1|Ml|4.1|ndeich|Buchs / Switzerland|earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30257637.00000|2008-12-13T06:02:23.0000|46.498000|10.059000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30257637.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30257451.00000|2008-11-09T07:22:31.0000|46.793000|9.204000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30257451.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/54990.00000|2008-07-14T03:51:41.0000|45.647000|10.478000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/54990.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/54831.00000|2008-06-17T19:48:07.0000|46.321000|7.331000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/54831.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/54411.00000|2008-02-17T12:41:31.0000|45.920000|7.171000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/54411.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30218793.00000|2007-05-19T16:19:38.0000|47.168000|10.605000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30218793.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/53823.00000|2007-03-23T05:01:38.0000|45.690000|9.867000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/53823.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52851.00000|2007-02-02T03:54:27.0000|47.581000|7.602000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52851.00000|Mw|3.0|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52837.00000|2007-01-16T00:09:07.0000|47.581000|7.604000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52837.00000|Mw|3.0|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30217904.00000|2006-12-08T16:48:39.0000|47.582000|7.600000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30217904.00000|Mw|3.2|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52562.00000|2006-10-20T00:11:58.0000|45.721000|10.332000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52562.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52439.00000|2006-07-22T18:08:16.0000|45.551000|10.198000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52439.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52270.00000|2006-04-12T22:24:53.0000|46.597000|10.255000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52270.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52243.00000|2006-03-29T09:49:45.0000|46.923000|6.858000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/52243.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30219904.00000|2005-11-12T19:31:16.0000|47.521000|8.166000|20.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30219904.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51764.00000|2005-09-08T11:27:17.0000|46.037000|6.889000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51764.00000|Mw|4.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51437.00000|2005-05-12T01:38:05.0000|47.265000|7.655000|25.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51437.00000|Mw|3.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51278.00000|2004-06-28T23:42:30.0000|47.525000|8.169000|20.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51278.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51260.00000|2004-06-21T23:10:02.0000|47.505000|7.713000|22.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51260.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51251.00000|2004-06-12T04:44:33.0000|45.717000|6.941000|12.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51251.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51191.00000|2004-02-23T17:31:21.0000|47.278000|6.270000|15.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51191.00000|Mw|4.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51184.00000|2004-02-18T14:31:58.0000|46.609000|6.995000|9.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51184.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51183.00000|2004-02-18T14:26:01.0000|46.607000|6.995000|9.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51183.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51077.00000|2003-08-22T09:30:09.0000|46.318000|7.315000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51077.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51075.00000|2003-08-22T09:21:32.0000|46.323000|7.316000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51075.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51051.00000|2003-08-01T03:20:23.0000|46.729000|9.837000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51051.00000|Mw|3.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51039.00000|2003-07-18T11:01:35.0000|46.723000|9.840000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51039.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51030.00000|2003-07-17T02:27:16.0000|46.729000|9.838000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/51030.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50980.00000|2003-05-06T21:59:43.0000|46.905000|8.908000|3.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50980.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50977.00000|2003-04-29T04:55:09.0000|46.341000|7.570000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50977.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50949.00000|2003-02-19T11:30:16.0000|46.295000|10.260000|12.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50949.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50943.00000|2003-02-04T20:49:40.0000|46.065000|7.765000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50943.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50936.00000|2003-01-29T08:00:04.0000|47.261000|10.191000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50936.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50894.00000|2002-11-13T10:48:03.0000|45.586000|10.147000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50894.00000|Mw|4.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/26718.00000|2002-05-31T16:50:33.0000|46.321000|7.359000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/26718.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50834.00000|2002-04-29T15:14:09.0000|46.102000|8.457000|21.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50834.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/26662.00000|2002-04-21T17:57:15.0000|45.790000|7.703000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/26662.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/26511.00000|2002-01-18T11:14:54.0000|46.565000|10.329000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/26511.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/26318.00000|2001-10-01T06:36:22.0000|46.553000|10.335000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/26318.00000|Mw|3.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/26224.00000|2001-07-09T22:50:02.0000|46.172000|7.626000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/26224.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514426.00000|2001-04-06T02:22:52.0000|45.870000|9.234000|22.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514426.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514413.00000|2001-03-17T00:29:59.0000|46.920000|9.006000|3.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514413.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514411.00000|2001-03-16T05:40:36.0000|47.214000|10.145000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514411.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514386.00000|2001-02-25T01:22:30.0000|46.133000|7.028000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514386.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514382.00000|2001-02-23T22:19:41.0000|46.136000|7.031000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514382.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514325.00000|2000-11-13T16:30:40.0000|47.222000|7.557000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514325.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514216.00000|2000-08-19T08:37:24.0000|46.027000|6.682000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514216.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514199.00000|2000-07-29T07:14:18.0000|45.852000|9.961000|14.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514199.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514132.00000|2000-06-10T05:51:02.0000|47.206000|10.104000|3.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514132.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514128.00000|2000-06-09T05:06:06.0000|46.527000|10.355000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514128.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514125.00000|2000-06-03T15:14:10.0000|47.206000|10.102000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514125.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514049.00000|2000-04-06T17:40:36.0000|46.533000|10.359000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514049.00000|Mw|4.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514047.00000|2000-04-06T00:43:18.0000|47.367000|7.168000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514047.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514012.00000|2000-03-04T15:43:19.0000|47.227000|9.474000|3.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514012.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514004.00000|2000-02-23T04:07:07.0000|47.046000|9.501000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514004.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514003.00000|2000-02-22T22:45:33.0000|46.851000|9.979000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/514003.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513922.00000|1999-12-31T04:55:53.0000|46.554000|10.335000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513922.00000|Mw|4.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513910.00000|1999-12-29T20:42:34.0000|46.550000|10.304000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513910.00000|Mw|4.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513908.00000|1999-12-29T09:29:29.0000|46.128000|6.931000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513908.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30228472.00000|1999-11-28T01:01:26.0000|45.538000|10.997000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30228472.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513873.00000|1999-10-31T12:03:55.0000|45.555000|10.346000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513873.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513868.00000|1999-10-28T04:54:22.0000|47.365000|10.087000|3.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513868.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513837.00000|1999-09-12T13:25:22.0000|47.578000|8.534000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513837.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513648.00000|1999-05-20T13:11:35.0000|46.653000|7.296000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513648.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513626.00000|1999-05-14T18:25:28.0000|46.737000|8.000000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513626.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513502.00000|1999-02-14T05:57:53.0000|46.793000|7.215000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513502.00000|Mw|4.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513425.00000|1998-12-09T22:08:14.0000|46.191000|7.552000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513425.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513411.00000|1998-12-07T13:46:25.0000|46.189000|7.556000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513411.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513252.00000|1998-05-07T17:16:43.0000|46.126000|7.393000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513252.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513226.00000|1998-04-21T02:30:56.0000|47.143000|9.344000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513226.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513201.00000|1998-03-23T13:07:18.0000|47.102000|9.137000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513201.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513091.00000|1997-11-22T04:56:10.0000|47.134000|9.189000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513091.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513059.00000|1997-10-23T12:07:01.0000|47.180000|8.626000|30.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/513059.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30226910.00000|1997-07-06T22:28:56.0000|45.483000|10.457000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30226910.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512866.00000|1997-04-12T23:00:00.0000|46.511000|10.438000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512866.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512652.00000|1996-08-24T02:38:22.0000|47.423000|9.045000|29.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512652.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512649.00000|1996-08-23T13:27:46.0000|46.761000|9.739000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512649.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512633.00000|1996-08-14T04:37:45.0000|46.343000|7.522000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512633.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512599.00000|1996-07-23T04:08:41.0000|45.947000|6.071000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512599.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512557.00000|1996-06-28T09:57:48.0000|47.118000|10.012000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512557.00000|Mw|3.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512524.00000|1996-06-15T21:40:09.0000|47.118000|10.019000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512524.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512484.00000|1996-05-17T09:30:59.0000|47.170000|9.488000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512484.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512459.00000|1996-04-27T06:59:59.0000|47.121000|10.032000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512459.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512421.00000|1996-03-31T06:08:01.0000|45.938000|7.460000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512421.00000|Mw|4.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512358.00000|1996-02-21T18:57:28.0000|46.368000|7.579000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512358.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512255.00000|1995-11-16T05:57:21.0000|47.057000|8.798000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512255.00000|Mw|3.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30225923.00000|1995-10-29T13:00:24.0000|45.541000|10.000000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30225923.00000|Mw|4.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512215.00000|1995-10-07T01:37:31.0000|46.797000|7.208000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512215.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512188.00000|1995-09-17T16:29:24.0000|46.787000|7.198000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512188.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512108.00000|1995-06-25T18:53:07.0000|47.603000|8.862000|11.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512108.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512073.00000|1995-05-24T20:45:37.0000|46.594000|6.388000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/512073.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1108.00000|1994-12-14T08:55:59.0000|45.958000|6.425000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1108.00000|Mw|4.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511794.00000|1994-08-28T06:04:45.0000|46.871000|8.772000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511794.00000|Mw|3.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511656.00000|1994-03-31T09:41:42.0000|47.132000|10.102000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511656.00000|Mw|4.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511545.00000|1993-12-09T18:16:50.0000|45.708000|10.258000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511545.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511290.00000|1993-07-10T08:59:09.0000|47.140000|10.114000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511290.00000|Mw|3.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511250.00000|1993-06-14T12:28:36.0000|46.003000|8.262000|19.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511250.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511048.00000|1992-12-30T21:34:12.0000|47.710000|8.380000|22.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/511048.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510991.00000|1992-11-02T15:13:26.0000|46.702000|8.423000|0.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510991.00000|Mw|3.7|||explosion
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510798.00000|1992-05-15T00:43:43.0000|47.158000|9.525000|11.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510798.00000|Mw|3.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510773.00000|1992-05-08T07:51:25.0000|47.144000|9.519000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510773.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510770.00000|1992-05-08T06:44:40.0000|47.145000|9.518000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510770.00000|Mw|4.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510731.00000|1992-03-28T19:24:16.0000|46.741000|9.512000|9.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510731.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510675.00000|1992-02-17T19:23:13.0000|46.726000|9.529000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510675.00000|Mw|3.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1098.00000|1991-11-20T01:54:17.0000|46.731000|9.527000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1098.00000|Mw|4.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510531.00000|1991-11-07T15:30:47.0000|47.153000|9.517000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510531.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510203.00000|1990-11-22T15:51:19.0000|46.893000|9.004000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510203.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/sc3a/1990swnlxj|1990-09-25T05:19:01.485915|46.181459|7.640554|5.0|tdiehl@sc3ag||SED|smi:ch.ethz.sed/sc3a/1990swnlxj|MLh|3.2|tdiehl@sc3ag|Zinal VS|earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510010.00000|1990-05-16T12:32:27.0000|46.858000|10.237000|15.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/510010.00000|Mw|3.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509958.00000|1990-03-18T09:54:30.0000|46.791000|9.834000|3.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509958.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509933.00000|1990-02-14T15:55:54.0000|46.283000|6.749000|17.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509933.00000|Ml|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509783.00000|1989-09-30T04:41:02.0000|46.328000|7.388000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509783.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509761.00000|1989-09-03T15:09:45.0000|47.759000|7.056000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509761.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509601.00000|1989-04-02T06:58:59.0000|47.123000|9.123000|12.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509601.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509552.00000|1989-02-21T23:36:50.0000|47.519000|8.856000|23.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509552.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509513.00000|1989-01-07T02:29:41.0000|46.345000|7.534000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509513.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509422.00000|1988-10-14T19:02:31.0000|46.701000|6.878000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509422.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509279.00000|1988-07-29T09:30:53.0000|46.395000|10.271000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509279.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509228.00000|1988-06-11T22:44:45.0000|45.861000|6.886000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/509228.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30221016.00000|1988-01-17T17:17:46.0000|45.633000|9.965000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30221016.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508971.00000|1987-12-11T02:25:58.0000|47.314000|7.163000|9.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508971.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508960.00000|1987-12-04T14:45:11.0000|45.838000|10.569000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508960.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508908.00000|1987-11-05T22:06:58.0000|46.413000|8.104000|13.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508908.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508893.00000|1987-10-28T23:49:00.0000|47.076000|9.206000|13.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508893.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508835.00000|1987-09-20T11:53:57.0000|46.758000|7.215000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508835.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508661.00000|1987-07-03T10:46:58.0000|45.522000|7.711000|15.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508661.00000|Mw|3.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508499.00000|1987-04-11T03:14:39.0000|47.430000|7.868000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508499.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508479.00000|1987-04-07T13:34:51.0000|46.512000|10.317000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508479.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508379.00000|1987-01-29T00:07:01.0000|47.426000|9.287000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508379.00000|Ml|3.2||Herisau AR|earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508000.00000|1986-02-27T12:07:06.0000|47.684000|8.958000|18.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/508000.00000|Mw|3.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507987.00000|1986-02-15T01:43:06.0000|46.061000|7.638000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507987.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507974.00000|1986-01-28T11:49:48.0000|46.434000|7.877000|12.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507974.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507954.00000|1986-01-17T07:05:30.0000|46.004000|6.879000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507954.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507609.00000|1985-06-18T04:52:56.0000|45.735000|10.917000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507609.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507558.00000|1985-05-21T17:43:27.0000|46.680000|10.628000|3.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507558.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507418.00000|1985-01-04T16:57:37.0000|46.002000|7.269000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507418.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507245.00000|1984-09-05T05:16:49.0000|47.247000|8.562000|15.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507245.00000|Mw|3.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507145.00000|1984-06-08T02:43:34.0000|46.688000|10.323000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/507145.00000|Mw|3.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506969.00000|1984-01-11T14:11:57.0000|47.335000|8.815000|11.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506969.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506829.00000|1983-10-24T19:58:11.0000|45.773000|10.440000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506829.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506635.00000|1983-08-31T00:18:27.0000|46.712000|10.360000|3.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506635.00000|Mw|3.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30221683.00000|1983-08-23T08:40:13.0000|45.623000|10.685000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30221683.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506604.00000|1983-07-31T20:52:56.0000|46.687000|10.520000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506604.00000|Mw|4.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506516.00000|1983-05-04T02:51:56.0000|46.308000|7.728000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506516.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506482.00000|1983-03-28T20:07:49.0000|46.148000|7.547000|3.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506482.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506397.00000|1983-01-03T17:03:06.0000|45.879000|9.437000|30.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506397.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506351.00000|1982-11-08T13:02:31.0000|46.100000|6.300000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/506351.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/505638.00000|1980-12-05T02:49:48.0000|46.555000|10.470000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/505638.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/505234.00000|1980-01-25T00:27:55.0000|46.502000|10.487000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/505234.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/505177.00000|1979-11-17T20:53:14.0000|45.578000|9.962000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/505177.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/505038.00000|1979-07-03T21:13:10.0000|46.922000|7.063000|30.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/505038.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504943.00000|1979-04-19T04:40:03.0000|45.680000|10.503000|2.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504943.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30270008.00000|1979-02-10T15:57:11.0000|45.518000|9.375000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30270008.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30263563.00000|1979-02-09T14:44:15.0000|45.640000|9.363000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30263563.00000|Mw|4.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504675.00000|1978-08-13T04:02:26.0000|47.270000|7.722000|23.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504675.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30258885.00000|1978-03-13T17:42:40.0000|45.782000|9.192000|11.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/30258885.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504573.00000|1978-02-23T09:49:20.0000|46.438000|9.815000|20.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504573.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504522.00000|1978-01-16T21:05:42.0000|45.813000|8.753000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504522.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504466.00000|1977-11-21T19:27:40.0000|47.282000|8.547000|27.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504466.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504367.00000|1977-08-07T13:27:05.0000|47.070000|10.629000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504367.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504357.00000|1977-07-27T07:50:17.0000|46.330000|7.427000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504357.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504280.00000|1977-03-31T09:40:36.0000|46.355000|7.476000|13.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504280.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504272.00000|1977-03-11T10:19:55.0000|46.408000|7.401000|16.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504272.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504270.00000|1977-03-10T02:01:42.0000|45.891000|10.113000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504270.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504267.00000|1977-03-08T02:55:40.0000|45.805000|10.031000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504267.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504265.00000|1977-03-05T13:31:22.0000|46.418000|7.390000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504265.00000|Mw|3.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504256.00000|1977-02-22T16:48:17.0000|46.495000|7.719000|15.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504256.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504206.00000|1976-12-26T08:59:35.0000|47.310000|9.644000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504206.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504110.00000|1976-07-17T09:50:09.0000|46.649000|9.753000|13.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504110.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504108.00000|1976-07-17T09:13:34.0000|46.682000|9.690000|9.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504108.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504104.00000|1976-07-10T22:36:28.0000|46.693000|9.655000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504104.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504049.00000|1976-03-26T22:28:31.0000|47.576000|9.443000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504049.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504031.00000|1976-03-02T08:27:57.0000|47.568000|9.435000|13.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504031.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504016.00000|1976-01-29T11:39:07.0000|46.235000|7.646000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504016.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504005.00000|1975-12-29T05:25:16.0000|47.115000|9.167000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/504005.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503992.00000|1975-11-25T06:17:35.0000|46.211000|7.482000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503992.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503948.00000|1975-09-07T20:39:05.0000|46.712000|9.738000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503948.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/10460.00000|1975-05-21T04:10:45.0000|45.752000|8.952000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/10460.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103057.00000|1974-08-15T17:16:17.0000|46.400000|7.400000|15.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103057.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103056.00000|1974-07-26T01:15:40.0000|46.800000|9.750000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103056.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103052.00000|1974-02-10T22:34:00.0000|46.683000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103052.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103051.00000|1974-01-19T02:50:49.0000|46.570000|7.370000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103051.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103050.00000|1974-01-15T20:11:09.0000|46.633000|7.367000|25.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103050.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103049.00000|1973-07-24T00:48:38.0000|47.117000|9.517000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103049.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103048.00000|1973-07-09T00:27:04.0000|46.767000|9.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103048.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103040.00000|1972-10-17T18:19:26.0000|46.840000|8.150000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103040.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103039.00000|1972-10-06T04:34:41.0000|46.200000|7.200000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103039.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103038.00000|1972-08-27T06:13:08.0000|47.317000|7.600000|18.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103038.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103036.00000|1972-03-22T00:10:11.0000|47.000000|9.250000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103036.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103035.00000|1972-02-28T01:27:26.0000|46.817000|6.733000|14.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103035.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103032.00000|1971-11-10T23:59:15.0000|46.150000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103032.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1071.00000|1971-09-29T07:18:52.0000|47.000000|9.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1071.00000|Mw|4.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103027.00000|1971-06-17T07:40:45.0000|47.660000|8.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103027.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103025.00000|1971-05-03T05:53:51.0000|47.417000|8.083000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103025.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103023.00000|1971-03-05T03:00:00.0000|46.200000|9.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103023.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2320.00000|1971-02-26T02:10:32.0000|46.700000|10.200000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2320.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103022.00000|1970-12-14T07:20:32.0000|46.750000|10.050000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103022.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103021.00000|1970-08-18T04:25:33.0000|46.400000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103021.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103020.00000|1970-08-06T13:54:50.0000|46.617000|9.850000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103020.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103018.00000|1970-07-23T12:58:27.0000|47.000000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103018.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103017.01000|1970-07-21T11:24:35.0000|46.637400|7.635500||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103017.01000|Mw|3.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103017.00000|1970-07-16T10:55:20.0000|46.767000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103017.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103015.00000|1970-05-10T01:49:00.0000|47.233000|9.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103015.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103012.00000|1970-03-11T02:32:12.0000|47.500000|9.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103012.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103011.00000|1970-03-07T08:01:07.0000|46.250000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103011.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103008.00000|1969-11-05T05:25:52.0000|46.767000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103008.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103007.00000|1969-09-10T04:27:26.0000|46.317000|8.083000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103007.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103006.00000|1969-09-10T03:26:58.0000|46.400000|8.200000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103006.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102998.00000|1968-08-13T18:02:55.0000|46.700000|9.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102998.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102987.00000|1968-05-07T21:44:27.0000|47.333000|9.117000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102987.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102986.00000|1968-04-25T18:27:40.0000|46.600000|9.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102986.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102984.00000|1968-03-07T00:21:45.0000|46.400000|7.500000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102984.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102983.00000|1968-02-29T14:17:00.0000|47.200000|9.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102983.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503215.00000|1968-01-28T16:27:10.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503215.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102978.00000|1967-12-11T02:36:16.0000|46.617000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102978.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102975.00000|1967-10-09T10:03:49.0000|46.550000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102975.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102974.00000|1967-10-08T15:27:15.0000|46.500000|7.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102974.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102972.00000|1967-09-24T22:27:00.0000|46.000000|9.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102972.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102971.00000|1967-09-14T20:21:01.0000|46.383000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102971.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102969.00000|1967-08-21T03:33:00.0000|46.783000|10.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102969.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102966.00000|1967-08-14T10:16:18.0000|46.950000|10.350000|20.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102966.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102964.00000|1967-07-21T21:48:59.0000|47.183000|9.383000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102964.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503166.00000|1967-07-18T00:58:03.0000|46.400000|6.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503166.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102963.00000|1967-07-15T02:23:26.0000|46.667000|8.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102963.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503138.00000|1967-03-24T17:38:38.0000|46.417000|7.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503138.00000|Mw|4.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50010836.00000|1966-12-12T07:36:36.0000|46.320000|7.320000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/50010836.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102954.00000|1966-09-02T10:15:04.0000|46.750000|9.000000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102954.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102953.00000|1966-06-22T09:09:55.0000|46.233000|7.500000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102953.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503098.00000|1966-06-22T08:41:58.0000|47.150000|7.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503098.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102952.00000|1966-06-09T14:17:12.0000|46.433000|7.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102952.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102951.00000|1966-04-22T01:39:00.0000|46.900000|8.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102951.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102948.00000|1966-03-16T11:23:46.0000|47.417000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102948.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102946.00000|1966-03-04T18:25:54.0000|46.900000|8.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102946.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102944.00000|1966-02-23T13:47:06.0000|46.167000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102944.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102942.00000|1966-02-22T00:20:42.0000|46.200000|7.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102942.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102941.00000|1966-02-12T23:42:46.0000|46.950000|8.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102941.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503069.00000|1966-01-28T17:52:49.0000|46.600000|7.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503069.00000|Mw|4.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102939.00000|1966-01-18T21:48:08.0000|46.467000|6.833000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102939.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102935.00000|1965-12-03T21:57:26.0000|46.283000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102935.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102933.00000|1965-11-11T11:52:28.0000|46.283000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102933.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102932.00000|1965-11-08T14:33:00.0000|46.900000|8.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102932.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102931.00000|1965-10-24T12:16:57.0000|46.300000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102931.00000|Mw|4.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102930.00000|1965-10-13T16:17:56.0000|46.300000|7.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102930.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102929.00000|1965-10-11T06:44:52.0000|46.900000|8.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102929.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102928.00000|1965-10-10T05:23:00.0000|47.100000|10.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102928.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102926.00000|1965-08-29T11:33:08.0000|46.250000|8.183000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102926.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102925.00000|1965-08-27T07:26:07.0000|46.830000|8.350000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102925.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102924.00000|1965-08-25T11:33:00.0000|46.367000|8.217000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102924.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102923.00000|1965-08-20T08:44:00.0000|46.900000|8.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102923.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102921.00000|1965-08-01T08:58:00.0000|46.733000|8.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102921.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102919.00000|1965-05-27T03:56:07.0000|46.233000|8.117000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102919.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503014.00000|1965-05-18T20:34:40.0000|47.000000|7.200000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/503014.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102917.00000|1965-04-14T04:11:54.0000|46.283000|7.483000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102917.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102916.00000|1965-02-10T04:43:47.0000|46.950000|8.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102916.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102913.00000|1964-11-11T02:57:00.0000|46.900000|8.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102913.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/502970.00000|1964-07-29T01:42:31.0000|46.600000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/502970.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102910.00000|1964-06-29T05:59:53.0000|46.750000|8.970000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102910.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102909.00000|1964-06-29T03:19:13.0000|46.770000|8.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102909.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102908.00000|1964-06-20T21:51:40.0000|46.767000|8.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102908.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102907.00000|1964-06-20T09:13:52.0000|46.770000|8.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102907.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102906.00000|1964-06-19T03:42:12.0000|46.700000|9.300000|12.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102906.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102905.00000|1964-06-18T09:02:39.0000|46.950000|8.330000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102905.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102904.00000|1964-05-28T20:52:03.0000|46.683000|9.033000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102904.00000|Mw|4.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102903.00000|1964-05-27T19:16:41.0000|46.900000|7.117000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102903.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2319.00000|1964-05-14T01:33:00.0000|46.830000|9.050000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2319.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102902.00000|1964-05-12T22:06:00.0000|46.900000|8.650000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102902.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102901.00000|1964-05-04T20:39:50.0000|47.650000|9.067000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102901.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102897.00000|1964-04-06T02:37:56.0000|46.650000|10.317000|3.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102897.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/502953.00000|1964-04-03T11:08:59.0000|46.800000|8.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/502953.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102890.00000|1964-03-16T13:30:36.0000|46.900000|8.250000|41.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102890.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102885.00000|1964-03-14T04:46:00.0000|46.900000|8.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102885.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1157.00000|1964-03-14T02:39:00.0000|46.867000|8.317000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1157.00000|Mw|5.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102881.00000|1964-03-13T15:42:19.0000|46.870000|8.350000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102881.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102880.00000|1964-03-11T19:19:08.0000|46.870000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102880.00000|Mw|4.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102879.00000|1964-03-10T16:00:29.0000|47.133000|9.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102879.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102871.00000|1964-02-26T03:22:48.0000|46.750000|8.983000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102871.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102870.00000|1964-02-25T18:17:20.0000|46.880000|8.370000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102870.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102867.00000|1964-02-20T05:08:10.0000|46.850000|8.270000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102867.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102866.00000|1964-02-18T21:53:50.0000|46.850000|8.230000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102866.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102860.00000|1964-02-18T06:08:04.0000|46.920000|8.280000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102860.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102854.00000|1964-02-17T16:09:40.0000|46.900000|8.300000|33.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102854.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1061.00000|1964-02-17T12:20:00.0000|46.880000|8.270000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1061.00000|Mw|4.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102849.00000|1964-02-07T00:58:31.0000|46.733000|8.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102849.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102848.00000|1964-02-02T19:46:35.0000|46.750000|8.983000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102848.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102846.00000|1964-01-27T10:23:00.0000|46.717000|8.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102846.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102845.00000|1964-01-25T07:27:00.0000|46.750000|8.983000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102845.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102844.00000|1964-01-22T20:15:00.0000|46.750000|8.983000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102844.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102842.00000|1964-01-21T10:14:25.0000|46.783000|9.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102842.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102840.00000|1964-01-10T04:28:50.0000|46.800000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102840.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102839.00000|1963-12-30T22:50:10.0000|46.700000|8.983000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102839.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102838.00000|1963-12-30T21:22:00.0000|46.717000|8.883000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102838.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102837.00000|1963-12-29T15:31:27.0000|46.533000|10.167000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102837.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102836.00000|1963-12-23T21:40:00.0000|46.733000|8.933000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102836.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102835.00000|1963-12-23T08:48:43.0000|46.367000|7.517000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102835.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102834.00000|1963-12-20T23:21:45.0000|46.750000|9.167000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102834.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102833.00000|1963-12-19T09:18:01.0000|45.783000|6.222000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102833.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102831.00000|1963-08-17T13:21:00.0000|47.100000|9.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102831.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102828.00000|1963-06-06T03:55:00.0000|46.267000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102828.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102827.00000|1963-03-22T23:57:00.0000|46.400000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102827.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102825.00000|1962-09-27T05:05:00.0000|46.267000|7.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102825.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102824.00000|1962-09-27T02:00:00.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102824.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102823.00000|1962-09-10T01:00:00.0000|46.300000|7.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102823.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102822.00000|1962-09-08T17:20:00.0000|47.570000|8.530000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102822.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102821.00000|1962-09-07T23:30:00.0000|46.300000|7.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102821.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102820.00000|1962-09-07T21:30:00.0000|46.300000|7.550000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102820.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102819.00000|1962-09-06T17:38:00.0000|46.300000|7.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102819.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102818.00000|1962-08-27T05:21:00.0000|46.283000|7.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102818.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102817.00000|1962-08-06T04:24:19.0000|46.200000|7.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102817.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102815.00000|1962-05-03T15:24:21.0000|46.560000|7.697000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102815.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102814.00000|1962-04-25T21:40:31.0000|46.250000|7.117000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102814.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102813.00000|1962-04-25T07:07:00.0000|46.250000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102813.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102811.00000|1962-03-02T02:01:00.0000|46.267000|7.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102811.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102810.00000|1962-03-02T00:12:00.0000|46.267000|7.550000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102810.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102809.00000|1962-02-28T04:51:00.0000|46.317000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102809.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102806.00000|1961-10-27T06:07:00.0000|46.883000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102806.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102804.00000|1961-09-10T17:26:00.0000|46.400000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102804.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102802.00000|1961-08-24T01:41:00.0000|46.800000|10.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102802.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102801.00000|1961-08-15T01:04:59.0000|46.800000|10.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102801.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/946.00000|1961-08-09T13:00:00.0000|46.810000|10.350000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/946.00000|Mw|4.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102795.00000|1961-06-02T01:54:00.0000|46.233000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102795.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102793.00000|1961-05-12T04:24:00.0000|47.000000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102793.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102791.00000|1961-03-24T10:07:00.0000|46.217000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102791.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102790.00000|1961-03-19T15:24:00.0000|45.950000|7.217000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102790.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102789.00000|1961-03-18T17:49:00.0000|46.283000|7.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102789.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102787.00000|1961-03-14T23:58:00.0000|46.200000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102787.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102786.00000|1961-03-14T14:10:00.0000|47.667000|9.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102786.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102785.00000|1961-02-14T20:34:58.0000|47.000000|9.717000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102785.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102784.00000|1961-02-02T06:33:54.0000|45.950000|8.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102784.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102781.00000|1961-01-17T01:51:57.0000|46.033000|7.467000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102781.00000|Mw|4.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102779.00000|1960-11-08T04:14:00.0000|46.900000|8.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102779.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102778.00000|1960-10-17T04:27:00.0000|46.267000|7.550000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102778.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102777.00000|1960-10-04T06:15:00.0000|45.855000|7.405000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102777.00000|Mw|4.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102775.00000|1960-06-19T03:35:14.0000|47.500000|7.300000|9.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102775.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102774.00000|1960-05-20T08:45:00.0000|47.367000|8.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102774.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102772.00000|1960-05-10T23:45:00.0000|47.367000|8.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102772.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102771.00000|1960-05-07T23:10:00.0000|47.367000|8.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102771.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102769.00000|1960-04-26T00:50:00.0000|47.500000|8.200000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102769.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1060.00000|1960-03-23T23:10:00.0000|46.370000|8.020000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1060.00000|Mw|5.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102763.00000|1960-02-06T20:40:00.0000|46.383000|7.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102763.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102762.00000|1960-02-06T20:35:00.0000|46.300000|7.530000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102762.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102761.00000|1960-02-06T20:34:00.0000|46.233000|7.350000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102761.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102758.00000|1960-01-02T10:36:00.0000|47.420000|9.370000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102758.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102756.00000|1959-11-02T17:34:00.0000|46.217000|6.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102756.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102755.00000|1959-09-26T18:47:14.0000|48.163000|10.243000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102755.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102750.00000|1959-08-31T10:44:04.0000|46.650000|9.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102750.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102748.00000|1959-07-03T04:58:34.0000|46.600000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102748.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102747.00000|1959-07-03T03:56:00.0000|46.183000|6.983000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102747.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102746.00000|1959-06-06T01:22:34.0000|46.850000|8.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102746.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102745.00000|1959-04-25T17:47:25.0000|47.400000|9.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102745.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102743.00000|1958-12-18T22:35:00.0000|46.283000|7.550000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102743.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102742.00000|1958-12-04T03:05:00.0000|46.833000|8.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102742.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102741.00000|1958-11-04T14:50:00.0000|46.183000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102741.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102740.00000|1958-10-12T01:58:00.0000|46.810000|10.350000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102740.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102739.00000|1958-10-11T06:35:00.0000|46.817000|8.650000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102739.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102737.00000|1958-09-15T19:14:23.0000|46.000000|7.750000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102737.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102735.00000|1958-08-29T05:39:31.0000|46.750000|9.750000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102735.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102734.00000|1958-08-14T00:55:00.0000|46.617000|7.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102734.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102733.00000|1958-07-30T12:51:10.0000|46.183000|8.717000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102733.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102732.00000|1958-07-25T02:25:53.0000|46.383000|7.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102732.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102731.00000|1958-04-12T05:53:28.0000|47.250000|9.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102731.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102728.00000|1958-02-11T19:48:00.0000|46.233000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102728.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102726.00000|1958-02-06T09:37:00.0000|46.233000|7.350000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102726.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102723.00000|1957-08-04T05:17:18.0000|47.533000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102723.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102719.00000|1957-05-01T18:49:50.0000|47.083000|9.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102719.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102715.00000|1956-12-25T20:04:30.0000|46.283000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102715.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102714.00000|1956-12-11T22:25:00.0000|46.250000|7.733000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102714.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102713.00000|1956-10-15T13:19:29.0000|46.417000|6.983000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102713.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102712.00000|1956-08-12T04:21:31.0000|46.333000|7.667000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102712.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102710.00000|1956-07-21T01:57:00.0000|46.087000|7.352000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102710.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102706.00000|1956-04-06T17:18:14.0000|46.250000|7.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102706.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102705.00000|1956-03-24T02:21:14.0000|46.250000|7.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102705.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102701.00000|1956-02-28T03:07:46.0000|46.500000|7.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102701.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102700.00000|1956-02-10T04:01:20.0000|46.000000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102700.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102698.00000|1956-01-28T04:21:30.0000|46.333000|7.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102698.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102696.00000|1956-01-04T18:29:10.0000|46.400000|7.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102696.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102694.00000|1955-12-26T10:52:00.0000|46.367000|7.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102694.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102693.00000|1955-12-24T23:40:29.0000|46.870000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102693.00000|Mw|3.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103856.02000|1955-12-21T12:45:00.0000|46.380000|8.530000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103856.02000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102692.00000|1955-12-21T11:45:00.0000|46.467000|9.517000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102692.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102690.00000|1955-11-23T06:27:50.0000|46.133000|6.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102690.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102688.00000|1955-10-19T21:20:00.0000|46.317000|7.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102688.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102687.00000|1955-09-12T22:09:00.0000|46.367000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102687.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102686.00000|1955-08-30T09:21:00.0000|46.350000|7.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102686.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102685.00000|1955-08-26T20:03:00.0000|46.583000|8.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102685.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102684.00000|1955-07-03T18:41:00.0000|46.367000|7.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102684.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102683.00000|1955-07-03T07:14:00.0000|46.367000|7.267000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102683.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102681.00000|1955-06-26T17:17:00.0000|46.317000|7.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102681.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102680.00000|1955-06-16T19:15:00.0000|46.367000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102680.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102679.00000|1955-05-22T02:58:00.0000|46.367000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102679.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102678.00000|1955-05-02T20:30:00.0000|46.333000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102678.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102677.00000|1955-05-02T08:31:00.0000|46.400000|7.267000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102677.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102676.00000|1955-04-26T05:28:00.0000|46.317000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102676.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102673.00000|1955-02-12T00:42:00.0000|46.300000|7.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102673.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102672.00000|1955-01-31T13:28:00.0000|46.983000|8.750000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102672.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102669.00000|1954-11-19T07:15:00.0000|46.400000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102669.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102668.00000|1954-11-13T23:30:00.0000|46.283000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102668.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102667.00000|1954-11-01T13:35:09.0000|47.017000|9.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102667.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102666.00000|1954-10-27T07:52:00.0000|46.167000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102666.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102665.00000|1954-10-23T23:46:00.0000|46.333000|7.383000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102665.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102660.00000|1954-09-24T05:13:00.0000|46.333000|7.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102660.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102659.00000|1954-09-24T05:08:00.0000|46.333000|7.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102659.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102658.00000|1954-09-18T14:28:00.0000|46.400000|7.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102658.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102656.00000|1954-09-14T22:53:00.0000|46.233000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102656.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102654.00000|1954-09-06T07:37:35.0000|46.367000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102654.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102652.00000|1954-08-30T16:52:00.0000|46.283000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102652.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102648.00000|1954-08-19T22:02:00.0000|46.563000|6.927000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102648.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102647.00000|1954-08-03T03:15:00.0000|46.383000|7.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102647.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102646.00000|1954-08-02T19:22:00.0000|46.383000|7.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102646.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102645.00000|1954-08-02T09:58:00.0000|46.383000|7.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102645.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102644.00000|1954-07-31T05:00:00.0000|46.383000|7.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102644.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102642.00000|1954-07-29T08:07:00.0000|46.283000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102642.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102641.00000|1954-07-29T04:40:27.0000|46.300000|7.500000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102641.00000|Mw|5.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102637.00000|1954-07-25T13:35:00.0000|46.283000|7.383000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102637.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102636.00000|1954-07-25T12:16:00.0000|46.300000|7.383000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102636.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102635.00000|1954-07-21T23:20:00.0000|46.317000|7.383000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102635.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102632.00000|1954-07-20T08:46:00.0000|46.283000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102632.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102630.00000|1954-07-18T21:20:00.0000|46.283000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102630.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102627.00000|1954-07-15T21:10:00.0000|46.400000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102627.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102625.00000|1954-07-15T08:58:29.0000|46.400000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102625.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102624.00000|1954-07-10T23:38:00.0000|46.683000|8.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102624.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102619.00000|1954-06-26T06:56:00.0000|46.267000|7.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102619.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102617.00000|1954-06-24T13:41:00.0000|46.433000|7.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102617.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102616.00000|1954-06-24T09:48:11.0000|46.250000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102616.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102612.00000|1954-06-17T12:44:00.0000|46.283000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102612.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102610.00000|1954-06-16T18:38:00.0000|46.283000|7.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102610.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102609.00000|1954-06-16T03:30:00.0000|46.333000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102609.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102608.00000|1954-06-15T02:58:00.0000|46.250000|7.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102608.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102606.00000|1954-06-14T13:21:57.0000|46.250000|7.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102606.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102605.00000|1954-06-14T05:34:43.0000|46.400000|7.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102605.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102600.00000|1954-06-04T05:56:00.0000|46.367000|7.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102600.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102599.00000|1954-06-03T06:35:00.0000|46.317000|7.183000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102599.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102597.00000|1954-05-30T11:31:00.0000|46.300000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102597.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102590.00000|1954-05-24T14:48:29.0000|46.400000|7.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102590.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102588.00000|1954-05-24T02:03:00.0000|46.383000|7.267000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102588.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102583.00000|1954-05-19T14:00:00.0000|46.280000|7.310000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102583.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1058.00000|1954-05-19T09:35:00.0000|46.280000|7.310000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1058.00000|Mw|5.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102579.00000|1954-04-19T12:44:00.0000|46.948000|8.483000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102579.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102578.00000|1954-04-14T18:39:00.0000|46.183000|6.967000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102578.00000|Mw|3.5|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102577.00000|1954-04-09T18:31:00.0000|46.950000|6.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102577.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102576.00000|1954-03-27T04:11:00.0000|46.317000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102576.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102575.00000|1954-03-22T21:40:00.0000|46.367000|7.167000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102575.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102574.00000|1954-03-13T11:52:00.0000|46.183000|7.267000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102574.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103727.01000|1954-02-04T22:00:00.0000|46.217000|6.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103727.01000|Mw|3.5|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102572.00000|1954-01-30T04:56:00.0000|46.550000|9.717000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102572.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103725.01000|1954-01-06T09:20:00.0000|46.198600|6.889400||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103725.01000|Mw|3.1|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102571.00000|1954-01-01T20:57:00.0000|46.183000|6.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102571.00000|Mw|3.5|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102570.00000|1953-12-31T00:20:00.0000|46.183000|6.933000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102570.00000|Mw|3.5|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102569.00000|1953-12-16T05:40:00.0000|46.183000|6.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102569.00000|Mw|3.5|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102567.00000|1953-12-02T05:41:00.0000|46.183000|6.883000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102567.00000|Mw|3.5|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102566.00000|1953-12-01T18:30:00.0000|46.183000|6.867000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102566.00000|Mw|3.5|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102565.00000|1953-11-07T14:00:00.0000|46.183000|6.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102565.00000|Mw|3.5|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102560.00000|1953-10-17T12:00:00.0000|46.183000|6.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102560.00000|Mw|3.5|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102557.00000|1953-10-14T01:20:00.0000|46.200000|6.883000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102557.00000|Mw|3.1|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102556.00000|1953-10-13T23:45:00.0000|46.200000|6.867000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102556.00000|Mw|3.1|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102553.00000|1953-10-12T02:20:00.0000|46.200000|6.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102553.00000|Mw|3.1|||induced or triggered event
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102552.00000|1953-09-30T10:59:00.0000|46.600000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102552.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102551.00000|1953-09-27T14:53:00.0000|46.100000|7.517000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102551.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102550.00000|1953-08-27T21:47:00.0000|46.367000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102550.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102549.00000|1953-08-27T01:47:00.0000|46.400000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102549.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102547.00000|1953-08-27T00:31:00.0000|46.433000|7.383000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102547.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102545.00000|1953-08-23T21:16:55.0000|47.300000|7.117000|13.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102545.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102544.00000|1953-08-21T06:46:20.0000|47.050000|9.117000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102544.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102543.00000|1953-08-12T21:39:57.0000|47.250000|7.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102543.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102541.00000|1953-06-24T12:07:00.0000|46.350000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102541.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102540.00000|1953-06-08T01:15:00.0000|46.900000|7.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102540.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102539.00000|1953-06-02T13:26:00.0000|46.617000|8.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102539.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102538.00000|1953-05-21T17:40:00.0000|46.333000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102538.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102537.00000|1953-05-05T01:25:00.0000|46.217000|7.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102537.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102536.00000|1953-03-03T07:28:00.0000|46.100000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102536.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102532.00000|1953-02-18T08:07:00.0000|46.317000|7.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102532.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102530.00000|1953-01-19T04:18:00.0000|46.350000|7.467000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102530.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102528.00000|1952-10-25T13:32:00.0000|46.817000|9.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102528.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102527.00000|1952-10-02T14:51:00.0000|46.850000|8.650000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102527.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102526.00000|1952-09-05T08:50:00.0000|46.333000|7.383000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102526.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102525.00000|1952-08-26T01:53:00.0000|46.233000|7.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102525.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102524.00000|1952-07-02T18:36:00.0000|46.300000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102524.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102523.00000|1952-05-09T11:18:00.0000|46.233000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102523.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102522.00000|1952-05-09T08:14:00.0000|46.233000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102522.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102521.00000|1952-05-09T08:09:00.0000|46.283000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102521.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102520.00000|1952-05-09T08:02:00.0000|46.417000|7.533000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102520.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102519.00000|1952-03-22T11:40:00.0000|46.417000|7.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102519.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102518.00000|1952-03-05T15:41:00.0000|46.233000|7.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102518.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102517.00000|1952-02-22T17:32:00.0000|46.233000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102517.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102516.00000|1952-01-15T02:23:00.0000|46.667000|7.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102516.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102514.00000|1951-12-30T00:49:00.0000|47.183000|8.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102514.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102512.00000|1951-11-03T02:26:00.0000|47.000000|6.930000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102512.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102508.00000|1951-08-20T19:49:00.0000|46.383000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102508.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102507.00000|1951-08-14T06:44:00.0000|46.317000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102507.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102505.00000|1951-08-01T09:55:38.0000|46.450000|7.500000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102505.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102503.00000|1951-07-24T09:28:00.0000|46.367000|7.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102503.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102502.00000|1951-07-20T15:25:00.0000|46.633000|8.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102502.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102501.00000|1951-07-17T21:17:00.0000|46.587000|7.527000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102501.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102498.00000|1951-06-25T21:46:00.0000|46.850000|8.650000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102498.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102496.00000|1951-06-20T00:24:00.0000|46.333000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102496.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102493.00000|1951-06-05T12:41:00.0000|46.317000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102493.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102492.00000|1951-06-03T18:40:00.0000|46.300000|7.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102492.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102491.00000|1951-06-01T04:18:00.0000|46.317000|7.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102491.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103642.02000|1951-05-16T02:27:00.0000|46.320000|8.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103642.02000|Mw|4.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102489.00000|1951-04-12T17:34:00.0000|46.317000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102489.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102486.00000|1951-03-09T21:19:00.0000|46.150000|7.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102486.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102485.00000|1951-03-04T05:11:00.0000|46.333000|7.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102485.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102484.00000|1951-03-03T09:26:00.0000|46.133000|7.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102484.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102483.00000|1951-02-28T08:12:00.0000|46.383000|7.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102483.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102482.00000|1951-01-29T00:46:00.0000|47.478000|10.723000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102482.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102481.00000|1951-01-28T23:48:00.0000|46.870000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102481.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102480.00000|1951-01-18T07:54:17.0000|46.767000|9.017000|6.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102480.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102479.00000|1951-01-14T12:47:00.0000|46.417000|7.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102479.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102478.00000|1951-01-05T10:05:00.0000|46.350000|7.467000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102478.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103629.01000|1950-12-21T12:26:00.0000|46.124000|7.503000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103629.01000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102477.00000|1950-11-25T11:39:00.0000|46.870000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102477.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102476.00000|1950-11-19T07:23:00.0000|46.283000|7.467000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102476.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102475.00000|1950-11-19T07:11:00.0000|46.333000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102475.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102474.00000|1950-11-19T07:08:00.0000|46.483000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102474.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102473.00000|1950-11-19T07:03:00.0000|46.483000|7.400000|3.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102473.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102471.00000|1950-11-16T13:07:00.0000|46.430000|7.430000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102471.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102470.00000|1950-11-15T12:29:00.0000|46.350000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102470.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102469.00000|1950-11-09T17:06:00.0000|46.317000|7.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102469.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102468.00000|1950-11-09T14:32:00.0000|46.300000|7.267000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102468.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102467.00000|1950-10-31T01:11:00.0000|47.500000|8.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102467.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102465.00000|1950-09-26T08:16:00.0000|47.533000|7.683000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102465.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102464.00000|1950-09-15T04:12:00.0000|46.283000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102464.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102463.00000|1950-09-14T03:30:00.0000|46.283000|7.350000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102463.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102460.00000|1950-08-09T07:53:00.0000|47.567000|7.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102460.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102458.00000|1950-07-19T15:25:33.0000|45.675000|6.765000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102458.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102457.00000|1950-07-11T09:17:00.0000|46.333000|7.467000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102457.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102455.00000|1950-06-23T08:04:00.0000|46.233000|7.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102455.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102454.00000|1950-06-21T11:46:58.0000|45.693000|7.245000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102454.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102452.00000|1950-05-28T10:19:00.0000|46.650000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102452.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102450.00000|1950-04-25T17:58:00.0000|46.317000|7.467000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102450.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102446.00000|1950-04-07T07:33:00.0000|47.300000|8.300000|17.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102446.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102445.00000|1950-04-06T03:24:00.0000|46.317000|7.467000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102445.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102444.00000|1950-04-03T01:39:00.0000|46.550000|10.017000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102444.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102443.00000|1950-02-26T11:41:00.0000|46.667000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102443.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102441.00000|1950-02-22T04:13:00.0000|46.400000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102441.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102439.00000|1950-01-10T12:07:00.0000|46.317000|7.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102439.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102438.00000|1949-12-28T07:22:00.0000|46.317000|7.550000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102438.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102437.00000|1949-11-21T16:31:00.0000|47.185000|6.908000|11.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102437.00000|Mw|3.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102436.00000|1949-11-13T17:21:00.0000|46.840000|8.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102436.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102433.00000|1949-10-19T03:15:00.0000|46.333000|7.550000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102433.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102431.00000|1949-10-05T16:06:00.0000|46.417000|7.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102431.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102430.00000|1949-10-05T15:55:00.0000|46.417000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102430.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102425.00000|1949-08-23T09:22:15.0000|46.883000|9.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102425.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102424.00000|1949-08-23T09:11:35.0000|46.870000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102424.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102423.00000|1949-08-19T04:28:00.0000|46.333000|7.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102423.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102422.00000|1949-08-16T01:07:00.0000|46.333000|7.517000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102422.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102420.00000|1949-08-04T20:10:00.0000|46.333000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102420.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102419.00000|1949-07-25T15:32:00.0000|46.150000|7.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102419.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102418.00000|1949-07-24T04:51:00.0000|46.133000|7.883000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102418.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102417.00000|1949-07-24T00:20:00.0000|46.133000|7.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102417.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102416.00000|1949-07-23T22:34:00.0000|46.133000|7.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102416.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102415.00000|1949-07-23T10:07:00.0000|46.117000|7.883000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102415.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102414.00000|1949-07-22T17:12:00.0000|46.117000|7.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102414.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102413.00000|1949-07-22T12:21:18.0000|46.067000|7.867000|29.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102413.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102412.00000|1949-07-17T19:15:00.0000|46.117000|7.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102412.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102411.00000|1949-07-17T11:21:00.0000|46.183000|7.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102411.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102407.00000|1949-06-16T15:13:00.0000|46.582000|6.877000|15.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102407.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102405.00000|1949-03-30T00:07:00.0000|46.333000|7.483000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102405.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102404.00000|1949-03-24T02:47:00.0000|46.233000|7.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102404.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102401.00000|1949-03-14T12:49:00.0000|46.665000|7.065000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102401.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102400.00000|1949-03-12T19:23:00.0000|46.317000|7.483000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102400.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102399.00000|1949-02-27T06:11:00.0000|46.300000|7.483000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102399.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102398.00000|1949-02-17T22:05:00.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102398.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102396.00000|1949-01-19T19:24:00.0000|46.200000|8.933000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102396.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102395.00000|1948-11-30T23:26:00.0000|47.450000|8.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102395.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102394.00000|1948-11-23T00:52:00.0000|47.417000|8.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102394.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102393.00000|1948-11-18T05:10:00.0000|46.150000|7.133000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102393.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102392.00000|1948-11-18T04:18:00.0000|46.733000|9.617000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102392.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102391.00000|1948-11-16T11:10:00.0000|47.450000|8.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102391.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102390.00000|1948-10-06T09:32:00.0000|46.500000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102390.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102389.00000|1948-09-17T13:25:00.0000|47.450000|8.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102389.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102388.00000|1948-08-06T19:04:00.0000|47.450000|8.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102388.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102385.00000|1948-08-04T23:53:00.0000|47.433000|8.683000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102385.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102383.00000|1948-08-03T16:12:00.0000|47.450000|8.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102383.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102382.00000|1948-08-03T15:13:00.0000|47.450000|8.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102382.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102381.00000|1948-08-02T22:29:00.0000|47.450000|8.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102381.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102379.00000|1948-07-05T10:46:00.0000|47.450000|8.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102379.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102378.00000|1948-05-30T04:41:00.0000|46.365000|7.528000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102378.00000|Mw|4.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102374.00000|1947-12-04T04:07:00.0000|46.483000|7.133000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102374.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102373.00000|1947-10-07T12:21:00.0000|46.667000|9.650000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102373.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102370.00000|1947-05-11T20:52:00.0000|46.683000|10.217000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102370.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102367.00000|1947-02-15T13:37:00.0000|46.450000|8.483000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102367.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102364.00000|1946-12-21T19:39:00.0000|46.550000|9.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102364.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102363.00000|1946-12-21T14:13:00.0000|46.533000|9.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102363.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102362.00000|1946-09-10T21:00:00.0000|45.877000|9.597000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102362.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20008.00000|1946-07-16T04:08:00.0000|46.300000|7.500000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20008.00000|Mw|4.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20007.00000|1946-05-30T03:41:00.0000|46.300000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20007.00000|Mw|5.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20006.00000|1946-05-30T00:35:00.0000|46.300000|7.520000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20006.00000|Mw|5.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20005.00000|1946-03-03T17:35:00.0000|46.300000|7.520000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20005.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102359.00000|1946-02-10T00:59:00.0000|47.017000|9.683000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102359.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2317.00000|1946-02-04T04:15:00.0000|46.300000|7.520000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2317.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20004.00000|1946-02-04T04:11:00.0000|46.300000|7.520000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20004.00000|Mw|4.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20003.00000|1946-01-26T03:15:00.0000|46.280000|7.430000|12.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20003.00000|Mw|4.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20002.00000|1946-01-25T21:40:00.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20002.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20001.00000|1946-01-25T20:40:00.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20001.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20009.00000|1946-01-25T17:32:00.0000|46.350000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20009.00000|Mw|5.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102355.00000|1945-11-13T21:45:00.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102355.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102354.00000|1945-11-10T06:40:00.0000|46.350000|7.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102354.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102353.00000|1945-11-03T13:54:00.0000|46.483000|7.133000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102353.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102352.00000|1945-10-13T00:08:00.0000|46.567000|9.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102352.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102350.00000|1945-06-16T23:47:00.0000|47.067000|9.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102350.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102349.00000|1945-05-13T03:17:00.0000|46.783000|7.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102349.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102348.00000|1945-04-13T12:12:00.0000|46.418000|7.620000|13.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102348.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102345.00000|1945-02-23T09:42:00.0000|46.650000|10.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102345.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102344.00000|1945-02-16T10:46:00.0000|46.422000|6.770000|1.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102344.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102343.00000|1945-02-05T04:58:00.0000|46.567000|9.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102343.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102342.00000|1944-10-13T20:24:00.0000|47.400000|9.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102342.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102340.00000|1944-07-19T20:18:00.0000|46.250000|7.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102340.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102337.00000|1944-03-30T01:45:00.0000|47.123000|8.528000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102337.00000|Mw|3.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102333.00000|1943-10-06T21:22:00.0000|47.333000|7.350000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102333.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102332.00000|1943-10-06T20:42:00.0000|46.913000|8.557000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102332.00000|Mw|3.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102331.00000|1943-08-16T03:41:00.0000|47.750000|8.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102331.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102329.00000|1943-07-04T08:09:00.0000|46.650000|10.183000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102329.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102321.00000|1942-12-06T20:01:00.0000|47.233000|9.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102321.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102319.00000|1942-11-10T06:50:00.0000|47.000000|7.167000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102319.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102318.00000|1942-11-09T00:12:00.0000|46.967000|7.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102318.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102317.00000|1942-10-30T00:18:55.0000|46.450000|7.133000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102317.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102315.00000|1942-08-28T11:28:58.0000|46.817000|8.267000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102315.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102314.00000|1942-08-27T11:11:20.0000|46.817000|8.267000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102314.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102313.00000|1942-07-18T15:46:00.0000|47.567000|7.433000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102313.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102310.00000|1942-07-01T23:42:55.0000|46.450000|7.133000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102310.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102309.00000|1942-06-25T22:13:00.0000|47.167000|9.267000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102309.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102307.00000|1942-02-17T11:14:00.0000|46.660000|7.638000|15.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102307.00000|Mw|3.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102305.00000|1941-04-06T06:32:00.0000|46.150000|7.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102305.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102304.00000|1941-03-29T21:51:00.0000|46.300000|7.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102304.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102303.00000|1941-03-12T20:44:30.0000|46.633000|8.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102303.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102302.00000|1941-02-05T02:27:00.0000|46.550000|9.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102302.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102301.00000|1941-01-18T02:28:45.0000|46.767000|6.750000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102301.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102299.00000|1940-12-12T01:36:20.0000|47.067000|9.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102299.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102298.00000|1940-11-22T21:30:00.0000|46.200000|7.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102298.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102297.00000|1940-11-07T16:23:20.0000|46.967000|8.750000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102297.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102296.00000|1940-10-17T12:00:00.0000|46.433000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102296.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102295.00000|1940-04-03T09:08:00.0000|47.367000|7.883000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102295.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102294.00000|1940-03-17T05:11:00.0000|47.583000|8.517000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102294.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102291.00000|1940-01-15T16:58:00.0000|46.733000|9.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102291.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102290.00000|1940-01-07T20:39:00.0000|46.567000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102290.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102289.00000|1940-01-07T20:12:00.0000|46.700000|9.600000|20.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102289.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102288.00000|1940-01-06T02:11:00.0000|46.183000|7.867000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102288.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102287.00000|1939-12-25T05:10:00.0000|46.233000|7.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102287.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102285.00000|1939-12-07T20:43:00.0000|47.400000|7.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102285.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102284.00000|1939-12-07T20:30:00.0000|46.517000|9.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102284.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102281.00000|1939-12-05T05:43:00.0000|47.400000|7.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102281.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102280.00000|1939-12-03T22:03:00.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102280.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102278.00000|1939-11-19T23:18:00.0000|46.217000|7.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102278.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102276.00000|1939-11-17T20:15:00.0000|47.350000|8.033000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102276.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102275.00000|1939-10-10T02:29:00.0000|46.233000|7.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102275.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102274.00000|1939-09-26T02:42:00.0000|46.770000|10.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102274.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102273.00000|1939-08-23T10:47:00.0000|46.083000|7.083000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102273.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102272.00000|1939-07-01T21:32:00.0000|47.550000|9.467000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102272.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102270.00000|1939-01-01T03:45:00.0000|46.317000|7.617000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102270.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102265.00000|1938-11-17T00:18:00.0000|47.550000|8.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102265.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102263.00000|1938-11-04T14:47:00.0000|46.233000|7.350000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102263.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102262.00000|1938-10-21T02:16:00.0000|46.400000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102262.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102261.00000|1938-09-23T00:52:00.0000|46.000000|7.400000|13.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102261.00000|Mw|4.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102260.00000|1938-07-22T19:41:00.0000|46.417000|9.717000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102260.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102259.00000|1938-05-28T04:40:00.0000|46.550000|9.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102259.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102258.00000|1938-04-18T00:30:00.0000|47.183000|8.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102258.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102256.00000|1938-02-18T02:02:00.0000|47.550000|8.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102256.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102255.00000|1938-01-02T17:10:00.0000|46.550000|9.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102255.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102254.00000|1937-12-01T22:18:00.0000|46.200000|7.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102254.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102253.00000|1937-11-16T16:05:00.0000|46.500000|9.883000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102253.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102250.00000|1937-11-15T01:47:00.0000|46.400000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102250.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102249.00000|1937-10-24T22:00:00.0000|46.800000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102249.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102248.00000|1937-10-17T16:50:00.0000|45.983000|7.117000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102248.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102247.00000|1937-10-03T02:15:00.0000|47.567000|8.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102247.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102246.00000|1937-09-30T15:31:00.0000|47.567000|9.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102246.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102244.00000|1937-06-30T08:13:00.0000|46.100000|7.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102244.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102240.00000|1937-06-07T01:25:00.0000|46.950000|6.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102240.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102238.00000|1937-05-10T14:33:00.0000|46.950000|6.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102238.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102235.00000|1937-04-14T19:04:00.0000|47.167000|7.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102235.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102234.00000|1936-08-26T23:33:00.0000|47.167000|9.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102234.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102233.00000|1936-08-26T22:12:00.0000|47.167000|9.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102233.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102231.00000|1936-08-07T13:47:00.0000|46.750000|10.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102231.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102230.00000|1936-08-07T07:47:00.0000|46.733000|10.117000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102230.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102229.00000|1936-07-31T02:02:00.0000|46.600000|7.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102229.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102228.00000|1936-07-01T21:32:00.0000|47.517000|9.433000|7.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102228.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102225.00000|1936-05-21T16:44:00.0000|46.433000|8.717000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102225.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102224.00000|1936-04-28T18:06:00.0000|46.517000|9.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102224.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102223.00000|1936-04-19T03:58:00.0000|46.300000|7.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102223.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1413.00000|1936-03-15T01:30:00.0000|47.550000|9.430000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1413.00000|Mw|4.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102218.00000|1936-01-18T20:35:00.0000|47.050000|7.033000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102218.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102217.00000|1935-12-06T01:10:00.0000|46.217000|7.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102217.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102214.00000|1935-07-28T14:07:00.0000|46.350000|7.083000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102214.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102213.00000|1935-07-10T18:03:00.0000|46.800000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102213.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103327.01000|1935-06-28T09:10:00.0000|47.174000|8.111000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103327.01000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102210.00000|1935-04-05T23:29:00.0000|45.867000|7.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102210.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102209.00000|1935-03-27T04:45:48.0000|46.450000|6.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102209.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102208.00000|1935-03-11T06:04:00.0000|47.050000|7.017000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102208.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1100.00000|1935-01-31T12:40:00.0000|47.690000|9.080000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1100.00000|Mw|4.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2316.00000|1935-01-31T09:18:00.0000|47.683000|9.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2316.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1119.00000|1935-01-31T09:10:00.0000|47.680000|9.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1119.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102199.00000|1934-11-27T23:57:00.0000|47.283000|8.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102199.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102197.00000|1934-11-21T21:52:00.0000|47.917000|8.533000|8.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102197.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102196.00000|1934-11-20T14:56:00.0000|46.583000|9.267000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102196.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102195.00000|1934-11-16T05:24:00.0000|46.233000|7.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102195.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102194.00000|1934-11-15T22:00:00.0000|46.233000|7.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102194.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102192.00000|1934-05-07T11:34:00.0000|47.150000|9.517000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102192.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102191.00000|1934-04-23T05:08:00.0000|46.200000|8.650000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102191.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102190.00000|1934-03-21T09:22:00.0000|47.083000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102190.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102188.00000|1933-12-09T01:52:00.0000|46.700000|6.467000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102188.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102186.00000|1933-09-24T23:55:05.0000|46.300000|7.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102186.00000|Mw|4.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102185.00000|1933-09-22T13:59:00.0000|46.433000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102185.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102183.00000|1933-09-17T04:08:00.0000|46.550000|7.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102183.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102182.00000|1933-08-31T18:41:00.0000|46.433000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102182.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102181.00000|1933-08-25T01:55:00.0000|45.967000|7.117000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102181.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102180.00000|1933-08-14T21:47:00.0000|46.500000|11.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102180.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103284.01000|1933-08-12T10:00:00.0000|46.683000|6.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103284.01000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1038.00000|1933-08-12T09:58:00.0000|46.660000|6.800000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1038.00000|Mw|4.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102177.00000|1933-06-19T02:00:00.0000|46.800000|9.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102177.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102175.00000|1933-01-24T01:43:00.0000|46.300000|7.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102175.00000|Mw|4.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102174.00000|1933-01-15T20:00:00.0000|47.433000|8.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102174.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102172.00000|1932-09-04T13:14:00.0000|47.350000|8.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102172.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102171.00000|1932-07-08T21:36:00.0000|47.420000|9.370000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102171.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102169.00000|1932-07-01T02:14:00.0000|47.317000|7.183000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102169.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102168.00000|1932-06-08T04:22:00.0000|46.633000|9.733000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102168.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102166.00000|1932-05-13T20:45:00.0000|46.233000|7.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102166.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102163.00000|1932-02-14T06:50:00.0000|47.367000|9.133000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102163.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102162.00000|1932-01-17T23:22:00.0000|47.600000|8.767000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102162.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102161.00000|1932-01-17T20:08:00.0000|47.600000|8.767000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102161.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102160.00000|1931-12-20T16:50:00.0000|46.383000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102160.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102159.00000|1931-11-29T02:23:00.0000|46.383000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102159.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102158.00000|1931-11-28T01:06:00.0000|46.500000|9.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102158.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102157.00000|1931-11-27T18:21:00.0000|46.383000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102157.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102149.00000|1931-04-23T11:06:00.0000|46.250000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102149.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102146.00000|1930-12-22T19:56:00.0000|46.950000|6.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102146.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102145.00000|1930-10-31T15:06:00.0000|47.570000|8.420000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102145.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102142.00000|1930-06-09T16:07:00.0000|46.933000|6.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102142.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102140.00000|1930-05-24T09:38:00.0000|46.200000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102140.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102139.00000|1930-05-24T06:35:00.0000|46.217000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102139.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102136.00000|1930-05-22T19:33:00.0000|46.233000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102136.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102135.00000|1930-05-22T04:56:00.0000|46.233000|7.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102135.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102134.00000|1930-05-11T00:15:00.0000|45.967000|8.867000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102134.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102132.00000|1930-01-18T23:19:00.0000|46.250000|7.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102132.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102130.00000|1930-01-14T21:47:00.0000|47.467000|7.750000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102130.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102129.00000|1930-01-09T05:30:00.0000|46.633000|10.267000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102129.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102127.00000|1929-12-25T19:40:00.0000|46.217000|7.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102127.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102126.00000|1929-12-25T03:43:00.0000|46.233000|7.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102126.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103220.02000|1929-12-21T02:28:00.0000|46.217000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103220.02000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103220.01000|1929-12-21T02:27:00.0000|46.217000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103220.01000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102125.00000|1929-12-21T02:25:00.0000|46.250000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102125.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103218.02000|1929-12-21T02:18:00.0000|46.217000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103218.02000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103218.01000|1929-12-21T02:12:00.0000|46.217000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103218.01000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102124.00000|1929-12-21T02:07:00.0000|46.217000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102124.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102123.00000|1929-12-21T01:43:00.0000|46.233000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102123.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102122.00000|1929-12-20T09:30:00.0000|46.250000|7.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102122.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102121.00000|1929-11-24T16:55:00.0000|46.217000|7.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102121.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102120.00000|1929-10-12T09:57:00.0000|46.667000|10.217000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102120.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102119.00000|1929-10-12T08:34:00.0000|46.667000|10.217000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102119.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102118.00000|1929-10-12T06:50:00.0000|46.667000|10.217000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102118.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1645.00000|1929-10-12T06:10:00.0000|46.667000|10.217000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1645.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102116.00000|1929-10-12T06:05:00.0000|46.667000|10.217000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102116.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102115.00000|1929-10-12T05:34:00.0000|46.667000|10.217000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102115.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102114.00000|1929-09-16T11:11:00.0000|47.167000|9.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102114.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102112.00000|1929-07-16T23:38:00.0000|46.870000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102112.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102111.00000|1929-05-03T12:30:00.0000|47.000000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102111.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102110.00000|1929-04-12T00:32:00.0000|46.817000|9.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102110.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102109.00000|1929-04-11T11:47:00.0000|46.817000|9.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102109.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102107.00000|1929-03-05T02:00:00.0000|46.500000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102107.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102106.00000|1929-03-04T03:37:00.0000|46.750000|6.733000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102106.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102105.00000|1929-03-03T02:21:00.0000|46.500000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102105.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1036.00000|1929-03-01T10:32:00.0000|46.730000|6.720000|5.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1036.00000|Mw|5.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102103.00000|1929-02-28T11:30:00.0000|46.750000|6.733000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102103.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102102.00000|1929-02-28T01:43:00.0000|46.750000|6.733000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102102.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102101.00000|1929-02-27T17:20:00.0000|47.390000|9.280000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102101.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102100.00000|1929-02-18T06:42:00.0000|46.233000|7.883000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102100.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102099.00000|1929-02-08T11:32:00.0000|46.817000|9.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102099.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102098.00000|1929-01-26T23:34:00.0000|47.200000|9.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102098.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102097.00000|1929-01-24T19:26:00.0000|46.450000|7.083000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102097.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103181.01000|1928-12-30T16:34:00.0000|46.163000|7.223000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103181.01000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102096.00000|1928-12-30T07:33:00.0000|47.550000|8.900000|40.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102096.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102094.00000|1928-12-05T03:18:00.0000|46.750000|6.717000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102094.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102092.00000|1928-11-18T14:52:00.0000|46.750000|6.717000|15.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102092.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102089.00000|1928-08-22T00:04:00.0000|46.700000|6.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102089.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102088.00000|1928-05-15T21:26:00.0000|46.750000|6.717000|12.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102088.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102087.00000|1928-05-11T15:25:00.0000|46.750000|6.717000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102087.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102085.00000|1928-02-16T20:08:00.0000|46.950000|8.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102085.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102082.00000|1928-02-06T21:44:00.0000|47.500000|9.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102082.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102081.00000|1928-01-27T13:22:00.0000|46.033000|7.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102081.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102079.00000|1927-12-27T05:30:00.0000|46.583000|9.933000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102079.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102078.00000|1927-12-23T05:47:00.0000|46.033000|7.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102078.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102076.00000|1927-10-13T06:46:00.0000|46.630000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102076.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102073.00000|1927-09-18T15:45:00.0000|46.150000|7.683000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102073.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102072.00000|1927-08-31T08:14:00.0000|47.017000|8.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102072.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103154.03000|1927-08-28T21:50:00.0000|46.433000|9.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103154.03000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102071.00000|1927-08-25T14:05:00.0000|46.483000|9.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102071.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102070.00000|1927-08-23T23:39:00.0000|46.450000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102070.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102069.00000|1927-08-19T01:15:00.0000|47.133000|7.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102069.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102068.00000|1927-08-13T01:40:00.0000|46.433000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102068.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103150.03000|1927-08-13T01:12:00.0000|46.433000|9.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103150.03000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103150.02000|1927-08-13T01:09:00.0000|46.433000|9.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103150.02000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102067.00000|1927-08-13T01:01:00.0000|46.433000|9.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102067.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102066.00000|1927-08-13T01:00:51.0000|46.500000|9.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102066.00000|Mw|4.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102065.00000|1927-08-11T19:21:00.0000|46.683000|7.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102065.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102064.00000|1927-07-03T03:05:00.0000|46.783000|10.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102064.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102063.00000|1927-01-08T07:17:00.0000|46.683000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102063.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1149.00000|1926-12-15T14:00:00.0000|46.750000|7.170000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1149.00000|Mw|4.0|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102061.00000|1926-11-30T10:56:11.0000|46.867000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102061.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102060.00000|1926-11-21T08:19:00.0000|46.150000|7.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102060.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102059.00000|1926-10-17T04:14:00.0000|46.783000|9.617000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102059.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102058.00000|1926-10-07T02:30:00.0000|47.550000|8.717000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102058.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102057.00000|1926-09-13T20:03:18.0000|47.217000|9.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102057.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102056.00000|1926-08-19T21:59:00.0000|46.583000|9.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102056.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102055.00000|1926-06-29T01:15:00.0000|47.350000|7.767000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102055.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102053.00000|1926-06-16T02:59:00.0000|46.867000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102053.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102052.00000|1926-06-08T00:22:00.0000|46.500000|6.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102052.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102051.00000|1926-05-05T21:45:00.0000|46.200000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102051.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102050.00000|1926-04-23T02:15:00.0000|46.250000|10.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102050.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102049.00000|1926-04-23T02:02:00.0000|46.733000|10.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102049.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102048.00000|1926-04-01T22:15:00.0000|45.800000|7.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102048.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102047.00000|1926-03-19T20:39:00.0000|47.583000|7.533000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102047.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103122.04000|1926-03-15T00:15:00.0000|46.483000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/103122.04000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102045.00000|1926-02-02T03:09:00.0000|46.683000|7.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102045.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102044.00000|1926-01-17T00:48:00.0000|46.483000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102044.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102043.00000|1925-12-29T06:35:00.0000|46.483000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102043.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102042.00000|1925-11-17T23:40:00.0000|46.833000|9.867000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102042.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102041.00000|1925-11-08T00:33:00.0000|46.400000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102041.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102037.00000|1925-07-17T04:43:00.0000|46.867000|6.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102037.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102034.00000|1925-02-22T19:47:00.0000|46.867000|6.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102034.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102033.00000|1925-02-05T05:47:00.0000|46.867000|6.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102033.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102031.00000|1925-01-09T03:50:00.0000|46.740000|6.390000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102031.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/960.00000|1925-01-08T02:45:00.0000|46.740000|6.390000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/960.00000|Mw|4.8|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102028.00000|1924-12-20T17:54:00.0000|46.870000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102028.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102025.00000|1924-11-19T17:55:00.0000|46.733000|6.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102025.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102024.00000|1924-11-13T23:11:00.0000|46.183000|7.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102024.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102023.00000|1924-11-07T10:55:00.0000|47.117000|9.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102023.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102020.00000|1924-07-27T14:27:00.0000|46.483000|9.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102020.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102019.00000|1924-07-23T22:37:00.0000|46.430000|9.760000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102019.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102018.00000|1924-07-03T21:26:00.0000|46.683000|7.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102018.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102017.00000|1924-06-08T06:37:00.0000|46.467000|7.117000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102017.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102015.00000|1924-05-15T08:10:00.0000|46.367000|7.767000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102015.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102012.00000|1924-04-21T22:24:00.0000|46.200000|7.950000|9.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102012.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102009.00000|1924-04-15T13:23:00.0000|46.250000|7.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102009.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/947.00000|1924-04-15T12:50:00.0000|46.300000|7.960000|10.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/947.00000|Mw|5.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102001.00000|1924-01-11T15:52:00.0000|46.567000|7.667000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102001.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102000.00000|1924-01-10T18:15:00.0000|46.900000|9.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102000.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101999.00000|1924-01-04T01:19:00.0000|46.620000|10.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101999.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101997.00000|1923-12-23T12:34:00.0000|46.783000|10.183000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101997.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101996.00000|1923-12-21T14:16:00.0000|46.767000|10.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101996.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101995.00000|1923-12-07T15:00:00.0000|46.467000|6.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101995.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101994.00000|1923-12-04T02:15:00.0000|46.433000|9.933000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101994.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101993.00000|1923-11-27T14:37:00.0000|46.600000|10.383000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101993.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101992.00000|1923-11-09T13:22:00.0000|46.220000|9.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101992.00000|Mw|4.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101991.00000|1923-11-05T02:35:00.0000|47.033000|8.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101991.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101989.00000|1923-10-30T22:12:00.0000|46.617000|9.983000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101989.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101988.00000|1923-10-30T15:35:00.0000|46.617000|9.983000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101988.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101987.00000|1923-09-17T04:30:00.0000|46.533000|8.933000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101987.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101986.00000|1923-09-11T06:25:00.0000|46.300000|7.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101986.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101984.00000|1923-06-10T11:14:00.0000|46.750000|8.350000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101984.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101983.00000|1923-06-06T02:19:00.0000|46.600000|10.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101983.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101982.00000|1923-06-05T20:35:00.0000|47.400000|8.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101982.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101981.00000|1923-06-05T19:50:00.0000|47.400000|8.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101981.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101980.00000|1923-05-16T10:06:00.0000|46.417000|8.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101980.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101979.00000|1923-04-29T09:57:00.0000|47.133000|9.483000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101979.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101978.00000|1923-01-22T08:17:00.0000|46.383000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101978.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101977.00000|1923-01-22T08:11:00.0000|46.383000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101977.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101974.00000|1922-12-16T08:59:51.0000|46.550000|8.483000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101974.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101969.00000|1922-11-08T22:24:00.0000|47.000000|9.083000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101969.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101968.00000|1922-09-19T13:46:00.0000|47.250000|8.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101968.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101962.00000|1922-06-09T23:10:00.0000|46.117000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101962.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101961.00000|1922-05-30T05:51:00.0000|47.333000|9.650000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101961.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101960.00000|1922-05-27T00:58:19.0000|46.700000|10.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101960.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101959.00000|1922-05-23T09:48:00.0000|46.820000|8.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101959.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101958.00000|1922-04-25T05:08:00.0000|46.330000|10.060000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101958.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101957.00000|1922-04-14T08:10:00.0000|47.633000|8.617000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101957.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101956.00000|1922-03-13T21:05:00.0000|47.383000|8.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101956.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101955.00000|1922-03-11T18:30:07.0000|47.400000|7.767000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101955.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101954.00000|1921-12-28T20:59:00.0000|47.000000|11.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101954.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101953.00000|1921-10-03T01:50:00.0000|47.000000|8.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101953.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101952.00000|1921-08-15T22:10:00.0000|47.583000|8.517000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101952.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101950.00000|1921-05-27T22:29:00.0000|46.600000|10.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101950.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101948.00000|1921-05-12T09:58:00.0000|46.200000|7.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101948.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101947.00000|1921-05-01T01:16:15.0000|46.783000|10.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101947.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101945.00000|1921-04-30T15:32:00.0000|46.783000|10.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101945.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101944.00000|1921-04-29T22:49:00.0000|46.233000|7.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101944.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101943.00000|1921-04-27T17:07:00.0000|46.750000|10.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101943.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101942.00000|1921-03-01T12:00:00.0000|46.750000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101942.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101941.00000|1921-03-01T11:55:00.0000|46.750000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101941.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101939.00000|1921-01-27T22:58:48.0000|46.750000|9.800000|23.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101939.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101938.00000|1921-01-07T22:00:00.0000|47.200000|7.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101938.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101937.00000|1920-12-05T15:28:00.0000|46.417000|10.020000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101937.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101936.00000|1920-11-20T23:20:00.0000|46.500000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101936.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101933.00000|1920-05-15T05:14:36.0000|47.200000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101933.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101929.00000|1920-04-15T21:56:00.0000|46.417000|8.133000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101929.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101926.00000|1920-04-01T18:33:00.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101926.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101925.00000|1920-04-01T18:26:35.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101925.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102971.05000|1920-03-31T04:58:00.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102971.05000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101924.00000|1920-03-30T01:04:14.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101924.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101923.00000|1920-03-29T11:00:00.0000|46.317000|7.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101923.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101922.00000|1920-03-29T09:59:00.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101922.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101919.00000|1919-12-25T17:00:00.0000|46.317000|9.133000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101919.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101916.00000|1919-12-14T02:35:42.0000|46.367000|7.767000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101916.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101915.00000|1919-12-07T01:00:00.0000|47.017000|9.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101915.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101914.00000|1919-11-26T01:10:00.0000|47.017000|9.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101914.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101913.00000|1919-11-22T09:45:10.0000|47.017000|9.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101913.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101912.00000|1919-11-22T03:45:00.0000|47.017000|9.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101912.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101911.00000|1919-11-21T07:30:00.0000|47.017000|9.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101911.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101910.00000|1919-11-16T22:00:00.0000|46.283000|7.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101910.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101908.00000|1919-11-16T12:00:00.0000|47.017000|9.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101908.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101909.00000|1919-11-16T04:25:47.0000|46.283000|7.317000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101909.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101907.00000|1919-09-21T03:20:00.0000|46.500000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101907.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101905.00000|1919-09-16T02:18:37.0000|46.450000|9.933000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101905.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101904.00000|1919-09-15T06:50:43.0000|46.450000|9.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101904.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101903.00000|1919-09-15T02:02:01.0000|46.450000|9.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101903.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101902.00000|1919-09-14T22:45:00.0000|46.433000|9.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101902.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101901.00000|1919-09-14T21:51:00.0000|46.433000|9.933000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101901.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101899.00000|1919-08-16T21:25:49.0000|46.283000|8.117000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101899.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101898.00000|1919-08-13T04:27:00.0000|46.750000|8.350000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101898.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101896.00000|1919-06-24T05:38:00.0000|46.567000|9.333000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101896.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101895.00000|1919-06-20T22:19:00.0000|46.383000|9.867000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101895.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101894.00000|1919-06-19T19:50:00.0000|46.383000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101894.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101891.00000|1919-03-14T05:30:00.0000|46.883000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101891.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101890.00000|1919-03-01T15:22:00.0000|46.883000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101890.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101888.00000|1919-02-19T04:34:00.0000|46.650000|7.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101888.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101887.00000|1919-02-17T16:50:00.0000|46.650000|7.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101887.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101884.00000|1919-01-22T19:23:49.0000|46.667000|9.667000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101884.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101883.00000|1919-01-04T03:18:28.0000|47.483000|9.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101883.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101882.00000|1919-01-03T06:10:00.0000|46.250000|7.010000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101882.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101881.00000|1919-01-03T06:05:00.0000|46.250000|7.050000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101881.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101880.00000|1919-01-03T05:55:00.0000|46.250000|7.050000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101880.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101879.00000|1918-12-31T04:30:00.0000|46.250000|7.050000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101879.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101878.00000|1918-12-31T04:25:00.0000|46.250000|7.050000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101878.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101877.00000|1918-12-31T00:13:05.0000|47.000000|11.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101877.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101876.00000|1918-12-28T09:45:00.0000|46.283000|7.050000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101876.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101874.00000|1918-12-04T21:44:00.0000|46.250000|7.050000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101874.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101873.00000|1918-11-30T13:10:03.0000|46.433000|9.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101873.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101871.00000|1918-11-13T20:19:00.0000|46.033000|7.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101871.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101870.00000|1918-10-22T02:51:00.0000|46.500000|6.483000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101870.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101869.00000|1918-10-21T20:21:00.0000|45.950000|7.200000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101869.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101867.00000|1918-08-14T14:12:00.0000|47.000000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101867.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101866.00000|1918-08-07T19:14:05.0000|46.430000|9.760000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101866.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101865.00000|1918-08-04T02:00:00.0000|46.667000|9.650000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101865.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101864.00000|1918-07-06T16:40:48.0000|46.233000|7.383000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101864.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101860.00000|1918-04-24T11:30:00.0000|46.550000|9.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101860.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101858.00000|1918-03-11T13:14:58.0000|46.767000|6.883000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101858.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101857.00000|1918-03-07T04:40:00.0000|46.383000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101857.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101854.00000|1918-02-03T19:14:00.0000|46.750000|9.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101854.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101853.00000|1918-02-02T22:43:51.0000|46.183000|7.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101853.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101852.00000|1918-01-24T15:50:44.0000|46.383000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101852.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101850.00000|1918-01-01T01:55:00.0000|46.533000|8.933000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101850.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101848.00000|1917-12-26T09:20:58.0000|46.483000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101848.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101847.00000|1917-12-20T11:45:00.0000|46.433000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101847.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101846.00000|1917-12-10T11:19:12.0000|46.483000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101846.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101844.00000|1917-12-10T05:39:10.0000|46.483000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101844.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101843.00000|1917-12-10T04:30:00.0000|46.600000|9.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101843.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101840.00000|1917-12-10T01:12:13.0000|46.483000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101840.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101845.00000|1917-12-10T01:00:51.0000|46.483000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101845.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101838.00000|1917-12-09T22:05:13.0000|46.483000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101838.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101837.00000|1917-12-09T22:02:17.0000|46.483000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101837.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1080.00000|1917-12-09T21:40:00.0000|46.460000|9.780000|15.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1080.00000|Mw|4.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101835.00000|1917-12-07T12:15:00.0000|46.810000|10.350000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101835.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101834.00000|1917-09-29T12:12:00.0000|46.667000|9.667000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101834.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101832.00000|1917-09-24T04:20:52.0000|46.717000|6.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101832.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101830.00000|1917-09-06T21:27:40.0000|46.983000|8.950000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101830.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101829.00000|1917-08-23T23:05:00.0000|46.883000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101829.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101828.00000|1917-08-09T07:37:00.0000|46.883000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101828.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101827.00000|1917-07-27T06:30:00.0000|46.850000|6.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101827.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102852.01000|1917-07-02T09:57:00.0000|46.880000|8.230000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102852.01000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101825.00000|1917-06-26T02:00:00.0000|46.150000|7.717000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101825.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101824.00000|1917-06-23T07:58:00.0000|47.000000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101824.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101823.00000|1917-06-22T21:15:00.0000|47.000000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101823.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101822.00000|1917-06-22T18:38:00.0000|46.883000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101822.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101821.00000|1917-06-22T18:24:00.0000|46.883000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101821.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1123.00000|1917-06-20T23:09:00.0000|47.610000|9.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1123.00000|Mw|4.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101818.00000|1917-06-14T05:21:00.0000|46.883000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101818.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101817.00000|1917-06-13T21:14:00.0000|46.883000|8.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101817.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101816.00000|1917-06-13T19:03:00.0000|46.883000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101816.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101815.00000|1917-05-14T22:17:00.0000|46.883000|8.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101815.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101814.00000|1917-05-14T21:27:00.0000|46.883000|8.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101814.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101812.00000|1917-04-03T20:45:00.0000|46.617000|10.383000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101812.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101809.00000|1917-03-27T16:41:59.0000|47.467000|7.517000|4.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101809.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101807.00000|1917-02-26T19:55:40.0000|47.000000|9.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101807.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101806.00000|1917-02-22T04:38:00.0000|46.883000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101806.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101805.00000|1917-02-19T09:09:00.0000|46.883000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101805.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101804.00000|1917-02-11T05:20:00.0000|46.767000|9.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101804.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101803.00000|1917-02-10T18:55:00.0000|46.883000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101803.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101802.00000|1917-02-09T08:00:32.0000|47.000000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101802.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101800.00000|1917-01-28T15:50:48.0000|47.270000|8.617000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101800.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102816.05000|1917-01-18T22:12:00.0000|46.500000|10.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102816.05000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102816.01000|1916-11-04T21:45:00.0000|46.810000|9.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102816.01000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101797.00000|1916-08-02T07:21:00.0000|46.400000|7.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101797.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101796.00000|1916-07-17T09:46:00.0000|47.400000|8.500000|18.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101796.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101794.00000|1916-03-10T00:55:00.0000|46.117000|7.033000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101794.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101792.00000|1916-01-16T22:10:00.0000|46.217000|9.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101792.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101790.00000|1916-01-09T09:11:00.0000|47.000000|7.250000|12.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101790.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101789.00000|1915-10-24T07:55:00.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101789.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101788.00000|1915-10-24T07:49:00.0000|46.300000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101788.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101787.00000|1915-10-23T08:31:23.0000|46.283000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101787.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101786.00000|1915-10-23T08:19:29.0000|46.300000|7.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101786.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/945.00000|1915-08-25T02:15:00.0000|46.100000|7.060000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/945.00000|Mw|4.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101784.00000|1915-08-17T14:46:07.0000|46.267000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101784.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101783.00000|1915-08-11T17:03:38.0000|46.267000|7.467000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101783.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101782.00000|1915-07-22T09:10:34.0000|46.267000|7.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101782.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101781.00000|1915-07-13T22:28:00.0000|47.250000|8.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101781.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101780.00000|1915-07-11T20:10:00.0000|46.867000|9.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101780.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101779.00000|1915-07-04T17:56:47.0000|46.950000|8.617000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101779.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101778.00000|1915-06-26T13:40:12.0000|46.950000|8.617000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101778.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101777.00000|1915-06-24T21:00:24.0000|46.950000|8.617000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101777.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101776.00000|1915-06-20T19:39:00.0000|47.300000|9.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101776.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101775.00000|1915-06-16T03:27:17.0000|46.267000|7.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101775.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101773.00000|1915-05-10T01:47:00.0000|45.867000|7.183000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101773.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102785.01000|1915-02-18T13:35:00.0000|45.950000|7.210000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102785.01000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101772.00000|1915-02-18T03:00:00.0000|46.033000|7.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101772.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101771.00000|1915-02-14T12:43:15.0000|46.850000|8.550000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101771.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101770.00000|1915-02-05T02:15:00.0000|46.333000|9.200000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101770.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101769.00000|1915-01-27T02:35:00.0000|46.483000|6.750000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101769.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101768.00000|1915-01-21T04:50:00.0000|46.967000|9.483000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101768.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101767.00000|1915-01-18T22:35:32.0000|47.183000|7.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101767.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101765.00000|1914-11-29T03:21:00.0000|46.117000|7.067000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101765.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101760.00000|1914-09-19T23:26:00.0000|47.350000|9.650000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101760.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101759.00000|1914-09-19T17:36:55.0000|47.420000|9.370000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101759.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2312.00000|1914-09-08T12:00:00.0000|47.260000|9.310000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2312.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101756.00000|1914-05-23T05:36:36.0000|46.750000|9.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101756.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101755.00000|1914-05-22T13:37:15.0000|46.750000|9.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101755.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101751.00000|1914-04-09T01:25:00.0000|46.267000|7.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101751.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101750.00000|1914-04-08T03:34:00.0000|46.733000|9.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101750.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101749.00000|1914-04-07T20:15:00.0000|46.870000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101749.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101748.00000|1914-03-20T04:00:00.0000|46.500000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101748.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102748.03000|1914-02-04T18:10:00.0000|47.030000|8.970000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102748.03000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102748.01000|1914-01-30T00:20:00.0000|47.038000|9.077000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102748.01000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101747.00000|1914-01-29T12:50:00.0000|46.600000|10.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101747.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101746.00000|1914-01-15T09:56:15.0000|46.767000|9.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101746.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101744.00000|1913-12-30T22:10:00.0000|46.870000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101744.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101743.00000|1913-12-22T11:38:00.0000|46.767000|9.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101743.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101741.00000|1913-12-10T22:10:50.0000|46.783000|9.467000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101741.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101740.00000|1913-12-10T13:40:00.0000|46.433000|6.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101740.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101739.00000|1913-11-11T07:58:45.0000|47.217000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101739.00000|Mw|4.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101738.00000|1913-11-02T01:50:00.0000|47.217000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101738.00000|Mw|4.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101736.00000|1913-10-06T22:50:00.0000|46.950000|9.033000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101736.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101734.00000|1913-09-28T07:11:00.0000|46.483000|9.500000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101734.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101730.00000|1913-06-02T12:45:00.0000|46.217000|7.617000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101730.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101729.00000|1913-06-01T12:55:50.0000|47.200000|7.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101729.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101728.00000|1913-05-21T23:46:00.0000|46.600000|10.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101728.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101727.00000|1913-05-21T22:20:40.0000|46.600000|10.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101727.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101726.00000|1913-04-21T20:25:00.0000|47.250000|8.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101726.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101725.00000|1913-03-09T16:49:00.0000|45.867000|7.183000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101725.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101724.00000|1913-03-06T02:00:00.0000|46.217000|7.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101724.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101722.00000|1913-01-15T06:00:00.0000|46.600000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101722.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101721.00000|1913-01-04T01:00:00.0000|47.670000|9.170000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101721.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101718.00000|1912-09-14T15:31:00.0000|47.250000|9.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101718.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101717.00000|1912-08-13T22:51:00.0000|46.317000|8.733000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101717.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101715.00000|1912-04-27T15:45:00.0000|46.750000|10.050000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101715.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101714.00000|1912-03-31T03:52:00.0000|47.217000|7.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101714.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101711.00000|1912-01-06T01:29:00.0000|46.717000|8.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101711.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2307.09000|1911-11-17T02:00:00.0000|47.390000|9.280000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2307.09000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101707.00000|1911-09-21T12:34:53.0000|47.517000|9.167000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101707.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2310.00000|1911-09-20T08:20:00.0000|47.500000|9.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2310.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101705.00000|1911-02-28T14:44:00.0000|46.633000|10.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101705.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101703.00000|1910-12-14T17:40:35.0000|46.870000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101703.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/801.00000|1910-12-07T19:00:00.0000|47.800000|7.610000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/801.00000|Mw|4.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101696.00000|1910-07-06T02:08:30.0000|47.267000|8.650000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101696.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/613.00000|1910-05-26T06:12:00.0000|47.480000|7.470000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/613.00000|Mw|4.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101694.00000|1910-04-11T00:31:00.0000|46.100000|7.083000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101694.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101692.00000|1910-02-03T01:24:00.0000|46.383000|9.917000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101692.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101691.00000|1910-02-01T04:00:00.0000|46.933000|6.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101691.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101685.00000|1909-12-28T01:29:00.0000|46.233000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101685.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101684.00000|1909-12-23T01:52:00.0000|46.450000|6.867000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101684.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101682.00000|1909-11-12T06:20:00.0000|46.617000|10.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101682.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101681.00000|1909-11-03T19:00:00.0000|46.600000|10.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101681.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101679.00000|1909-10-15T05:56:09.0000|47.467000|7.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101679.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101677.00000|1909-10-01T02:22:00.0000|46.900000|9.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101677.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101676.00000|1909-08-20T04:00:00.0000|46.917000|8.267000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101676.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101675.00000|1909-04-27T12:00:00.0000|46.917000|6.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101675.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101673.00000|1909-03-13T12:40:00.0000|46.217000|7.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101673.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101672.00000|1909-02-20T16:50:00.0000|47.217000|7.183000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101672.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101671.00000|1909-02-17T16:50:00.0000|46.450000|6.867000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101671.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101669.00000|1909-02-13T04:07:00.0000|46.983000|6.867000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101669.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101664.00000|1909-02-06T01:30:00.0000|46.983000|6.867000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101664.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101663.00000|1909-02-01T02:40:00.0000|46.983000|6.883000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101663.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101661.00000|1909-01-18T01:25:00.0000|47.000000|6.930000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101661.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101660.00000|1909-01-15T21:00:00.0000|47.033000|6.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101660.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101659.00000|1909-01-05T17:20:00.0000|46.150000|7.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101659.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102642.01000|1908-05-24T07:00:00.0000|46.000000|9.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102642.01000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101652.00000|1907-10-12T22:45:00.0000|46.850000|7.200000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101652.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101649.00000|1907-09-17T23:25:00.0000|46.383000|9.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101649.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101648.00000|1907-08-22T21:03:00.0000|46.567000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101648.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101646.00000|1907-07-11T11:46:00.0000|46.917000|9.550000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101646.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101644.00000|1907-05-02T22:10:00.0000|46.567000|6.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101644.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101643.00000|1907-04-27T02:00:00.0000|47.750000|8.633000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101643.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101642.00000|1907-04-27T00:15:00.0000|47.383000|9.167000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101642.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101640.00000|1907-03-30T00:10:00.0000|47.000000|6.930000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101640.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101639.00000|1907-03-23T16:30:00.0000|46.667000|8.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101639.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101638.00000|1907-03-15T19:57:00.0000|47.317000|9.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101638.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101637.00000|1907-03-15T02:45:00.0000|47.367000|9.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101637.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102620.01000|1907-03-11T22:00:00.0000|47.670000|9.170000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102620.01000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101635.00000|1907-03-11T02:40:00.0000|47.133000|8.583000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101635.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101634.00000|1907-02-21T01:00:00.0000|47.033000|8.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101634.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101633.00000|1907-02-16T23:03:00.0000|46.850000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101633.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101632.00000|1907-01-21T05:02:00.0000|46.850000|9.283000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101632.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101630.00000|1906-12-15T01:27:00.0000|46.800000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101630.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101628.00000|1906-11-24T13:26:52.0000|46.800000|9.833000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101628.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101624.00000|1906-03-21T12:57:00.0000|46.583000|8.617000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101624.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101623.00000|1906-03-21T00:50:00.0000|47.083000|9.967000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101623.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102600.03000|1906-01-01T03:00:00.0000|46.870000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102600.03000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2304.09000|1905-12-29T18:20:00.0000|46.700000|9.430000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2304.09000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/241.00000|1905-12-26T00:25:00.0000|46.880000|9.430000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/241.00000|Mw|4.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2298.09000|1905-12-25T20:00:00.0000|46.970000|6.540000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/2298.09000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101614.00000|1905-12-25T17:30:00.0000|46.800000|9.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101614.00000|Mw|3.6|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/239.00000|1905-12-25T17:05:00.0000|46.810000|9.480000|12.0|||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/239.00000|Mw|4.7|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101612.00000|1905-12-12T04:35:00.0000|46.833000|9.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101612.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101609.00000|1905-12-06T00:29:00.0000|46.100000|7.017000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101609.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101608.00000|1905-12-06T00:08:00.0000|46.100000|7.000000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101608.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101607.00000|1905-11-23T20:20:00.0000|46.367000|10.367000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101607.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101606.00000|1905-10-10T20:45:00.0000|47.200000|9.450000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101606.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101604.00000|1905-08-16T20:57:00.0000|47.367000|8.700000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101604.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101602.00000|1905-07-03T08:47:00.0000|47.000000|9.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101602.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101600.00000|1905-04-14T22:20:00.0000|46.520000|10.650000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101600.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101598.00000|1904-12-04T05:20:00.0000|46.933000|9.417000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101598.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101597.00000|1904-11-22T05:25:00.0000|47.300000|9.600000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101597.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101596.00000|1904-08-31T01:10:00.0000|46.450000|7.050000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101596.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101595.00000|1904-08-26T18:00:00.0000|46.650000|6.783000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101595.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101592.00000|1904-05-02T11:35:00.0000|47.667000|8.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101592.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1084.00000|1904-03-28T13:20:00.0000|46.770000|7.240000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/1084.00000|Mw|4.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101589.00000|1904-01-11T10:23:00.0000|46.833000|9.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101589.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101588.00000|1903-11-03T10:29:00.0000|46.450000|6.883000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101588.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101587.00000|1903-09-26T22:20:00.0000|46.567000|6.817000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101587.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101586.00000|1903-09-17T18:30:00.0000|46.317000|7.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101586.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101584.00000|1903-09-09T04:38:00.0000|46.483000|9.850000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101584.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101583.00000|1903-07-11T03:45:00.0000|46.767000|9.567000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101583.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101579.00000|1903-01-19T13:23:00.0000|46.810000|9.841000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101579.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101578.00000|1903-01-03T03:57:00.0000|46.980000|9.480000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101578.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101577.00000|1902-12-06T03:10:00.0000|47.000000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101577.00000|Mw|4.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101574.00000|1902-07-11T12:00:00.0000|47.567000|8.900000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101574.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101571.00000|1902-01-21T20:45:00.0000|46.867000|8.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101571.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101570.00000|1902-01-21T20:40:00.0000|47.000000|8.300000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101570.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101567.00000|1901-11-29T16:00:00.0000|46.600000|10.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101567.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101563.00000|1901-10-28T06:00:00.0000|46.600000|10.433000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101563.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101562.00000|1901-10-02T01:25:00.0000|46.430000|9.760000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101562.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101561.00000|1901-07-14T16:22:00.0000|46.380000|6.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101561.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101558.00000|1901-04-26T12:00:00.0000|46.550000|9.233000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101558.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102518.01000|1901-02-17T07:42:00.0000|46.497000|6.260000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/102518.01000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20.00000|1901-02-17T05:30:00.0000|46.380000|6.250000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/20.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101554.00000|1901-02-15T16:15:00.0000|46.870000|9.533000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101554.00000|Mw|3.1|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101553.00000|1901-02-15T05:30:00.0000|46.450000|6.400000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101553.00000|Mw|4.4|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101551.00000|1901-02-12T04:20:00.0000|46.733000|10.150000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101551.00000|Mw|3.2|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101550.00000|1900-12-10T18:00:00.0000|46.870000|9.530000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101550.00000|Mw|3.9|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101549.00000|1900-10-26T06:00:00.0000|46.917000|9.167000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101549.00000|Mw|3.5|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/17.00000|1900-08-06T23:00:00.0000|47.000000|9.100000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/17.00000|Mw|4.3|||earthquake
+smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101545.00000|1900-05-18T00:24:00.0000|46.383000|6.800000||||SED_ECOS-09|smi:ch.ethz.sed/event/ecos09/GROUP_PEGASOS/101545.00000|Mw|3.5|||earthquake

--- a/catalogue_tools/download/tests/test_download_catalogues.py
+++ b/catalogue_tools/download/tests/test_download_catalogues.py
@@ -1,11 +1,28 @@
 import datetime as dt
-from numpy.testing import assert_equal
+import os
+from unittest import mock
+
 import numpy as np
+from numpy.testing import assert_equal
 
 from catalogue_tools.download.download_catalogues import download_catalog_sed
 
+PATH_RESOURCES = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                              'data')
 
-def test_download_catalogue_sed():
+
+def mocked_requests_get(*args, **kwargs):
+    response = mock.MagicMock()
+    response.getcode.return_value = 200
+
+    with open(f'{PATH_RESOURCES}/catalog.csv', 'rb') as f:
+        response.read.return_value = f.read()
+
+    return response
+
+
+@mock.patch('urllib.request.urlopen', side_effect=mocked_requests_get)
+def test_download_catalogue_sed(mock_get):
     min_mag = 3.0
     start_time = dt.datetime(1900, 1, 1)
     end_time = dt.datetime(2022, 1, 1)
@@ -28,7 +45,3 @@ def test_download_catalogue_sed():
         (['MLh', 'MLhc', 'Ml', 'Mw'],
          [93, 15, 32, 1134])
     )
-
-
-if __name__ == '__main__':
-    test_download_catalogue_sed()

--- a/catalogue_tools/recurrence/tests/test_wls.py
+++ b/catalogue_tools/recurrence/tests/test_wls.py
@@ -29,8 +29,5 @@ def test_wls():
     als, als_u, bls, bls_u = weighted_least_squares(
         years, magnitudes, completeness_table)
 
-    print('a = %.4f (+/- %.4f)  b = %.4f (+/- %.4f)' %
-          (als, als_u, bls, bls_u))
-
     assert_array_almost_equal([als, als_u, bls, bls_u],
                               [5.1076, 0.1304, 0.9796, 0.0254], 4)


### PR DESCRIPTION
The test you wrote has a dependency to something over which you don't have control, which you try to avoid:
> If for any reason the Arclink catalog is not available anymore, or even if the length changes, this test will not succeed, even though the code is still correct.

The solution is to mock the request. Meaning, you "intercept" the 'urllib.request.urlopen' method and return something which will always be the same.

the 'urllib.requet.urlopen' method is an external function which can be relied on to always work, therefore you don't need to test whether it works to get the catalog, but you need to test if that information is parsed correctly (ie. what your method does). 